### PR TITLE
Tab-based course overview page for Teacher

### DIFF
--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseHeader.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseHeader.razor
@@ -1,0 +1,47 @@
+﻿<div class="d-flex flex-column gap-3 mb-4">
+    <div>
+        <a href="@BackUrl" class="text-decoration-none d-inline-flex align-items-center gap-2 small">
+            <i class="bi bi-arrow-left"></i>
+            <span>@BackText</span>
+        </a>
+    </div>
+
+    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+        <div class="flex-grow-1">
+            <h1 class="h2 fw-bold mb-2">@Title</h1>
+
+            @if (!string.IsNullOrWhiteSpace(Description))
+            {
+                <p class="text-muted mb-3">@Description</p>
+            }
+
+            <div class="d-flex align-items-center gap-2 text-muted small">
+                <i class="bi bi-calendar-event"></i>
+                <span>@StartDate.ToString("yyyy-MM-dd") - @EndDate.ToString("yyyy-MM-dd")</span>
+            </div>
+        </div>
+
+        @if (ShowEditButton)
+        {
+            <button type="button" class="btn btn-primary d-inline-flex align-items-center gap-2" @onclick="OnEditClicked">
+                <i class="bi bi-pencil-square"></i>
+                <span>@EditButtonText</span>
+            </button>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = "Kursnamn";
+    [Parameter] public string? Description { get; set; }
+    [Parameter] public DateTime StartDate { get; set; } = DateTime.Today;
+    [Parameter] public DateTime EndDate { get; set; } = DateTime.Today.AddMonths(3);
+
+    [Parameter] public string BackUrl { get; set; } = "/";
+    [Parameter] public string BackText { get; set; } = "Tillbaka till dashboard";
+
+    [Parameter] public bool ShowEditButton { get; set; } = true;
+    [Parameter] public string EditButtonText { get; set; } = "Redigera kurs";
+
+    [Parameter] public EventCallback OnEditClicked { get; set; }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseOverviewModels.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseOverviewModels.cs
@@ -1,0 +1,71 @@
+﻿namespace LMS.Blazor.Client.Components.TeacherCourseOverview;
+
+public class ModuleProgressModel
+{
+    public string Name { get; set; } = "";
+    public int Progress { get; set; }
+}
+
+public class CourseStatisticsModel
+{
+    public int Modules { get; set; }
+    public int Activities { get; set; }
+    public int Students { get; set; }
+    public int Submissions { get; set; }
+}
+
+public class ActivityModel
+{
+    public string Title { get; set; } = "";
+    public string Time { get; set; } = "";
+    public ActivityType Type { get; set; }
+}
+
+public class ModuleModel
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Title { get; set; } = "";
+    public string Description { get; set; } = "";
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+    public int Progress { get; set; }
+    public bool IsExpanded { get; set; }
+    public List<ModuleActivityModel> Activities { get; set; } = [];
+}
+
+public class ModuleActivityModel
+{
+    public string Title { get; set; } = "";
+    public ModuleActivityType Type { get; set; }
+    public DateTime Date { get; set; }
+    public DateTime? Deadline { get; set; }
+    public bool ShowSubmissionButton { get; set; }
+    public List<ModuleDocumentModel> Documents { get; set; } = [];
+}
+
+public class ModuleDocumentModel
+{
+    public string FileName { get; set; } = "";
+    public string FileSize { get; set; } = "";
+}
+public class StudentListItemModel
+{
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public int ProgressPercent { get; set; }
+    public DateTime LastActive { get; set; }
+}
+
+public enum ModuleActivityType
+{
+    Lecture,
+    Exercise,
+    Assignment
+}
+
+public enum ActivityType
+{
+    Submission,
+    Document,
+    Module
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseTabs.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseTabs.razor
@@ -1,0 +1,32 @@
+﻿<nav class="border-bottom mb-4">
+    <ul class="nav nav-tabs border-0">
+        @foreach (var tab in Tabs)
+        {
+            <li class="nav-item">
+                <a href="@tab.Url"
+                       class="nav-link border-0 px-0 me-4 @(tab.IsActive ? "active fw-semibold text-primary border-bottom border-2 border-primary bg-transparent" : "text-secondary bg-transparent")">
+                    @tab.Label
+                </a>
+            </li>
+        }
+    </ul>
+</nav>
+
+@code {
+    [Parameter]
+    public List<CourseTabItem> Tabs { get; set; } = new()
+    {
+        new() { Label = "Översikt", Url = "#", IsActive = true },
+        new() { Label = "Moduler", Url = "#" },
+        new() { Label = "Inlämningar", Url = "#" },
+        new() { Label = "Studenter", Url = "#" },
+        new() { Label = "Dokument", Url = "#" }
+    };
+
+    public class CourseTabItem
+    {
+        public string Label { get; set; } = string.Empty;
+        public string Url { get; set; } = "#";
+        public bool IsActive { get; set; }
+    }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseTabs.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseTabs.razor
@@ -3,10 +3,11 @@
         @foreach (var tab in Tabs)
         {
             <li class="nav-item">
-                <a href="@tab.Url"
-                       class="nav-link border-0 px-0 me-4 @(tab.IsActive ? "active fw-semibold text-primary border-bottom border-2 border-primary bg-transparent" : "text-secondary bg-transparent")">
+                <button type="button"
+                        class="nav-link border-0 px-0 me-4 fw-semibold @(tab.IsActive ? "active fw-semibold text-primary border-bottom border-2 border-primary bg-transparent" : "text-secondary bg-transparent")"
+                        @onclick="() => SelectTab(tab.Label)">
                     @tab.Label
-                </a>
+                </button>
             </li>
         }
     </ul>
@@ -16,17 +17,29 @@
     [Parameter]
     public List<CourseTabItem> Tabs { get; set; } = new()
     {
-        new() { Label = "Översikt", Url = "#", IsActive = true },
-        new() { Label = "Moduler", Url = "#" },
-        new() { Label = "Inlämningar", Url = "#" },
-        new() { Label = "Studenter", Url = "#" },
-        new() { Label = "Dokument", Url = "#" }
+        new() { Label = "Översikt", IsActive = true },
+        new() { Label = "Moduler" },
+        new() { Label = "Inlämningar" },
+        new() { Label = "Studenter" },
+        new() { Label = "Dokument" }
     };
+
+    [Parameter]
+    public EventCallback<string> OnTabChanged { get; set; }
+
+    private async Task SelectTab(string label)
+    {
+        foreach (var tab in Tabs)
+        {
+            tab.IsActive = tab.Label == label;
+        }
+
+        await OnTabChanged.InvokeAsync(label);
+    }
 
     public class CourseTabItem
     {
         public string Label { get; set; } = string.Empty;
-        public string Url { get; set; } = "#";
         public bool IsActive { get; set; }
     }
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleActivityItem.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleActivityItem.razor
@@ -1,0 +1,80 @@
+﻿<div class="border rounded-4 p-3">
+    <div class="d-flex justify-content-between align-items-start gap-3">
+        <div class="min-w-0">
+            <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
+                <span class="@GetBadgeClass()">@GetTypeLabel()</span>
+                <span class="fw-semibold fs-5">@Activity.Title</span>
+            </div>
+
+            <div class="text-secondary mb-3">
+                <i class="bi bi-calendar3 me-1"></i>
+                @Activity.Date.ToString("yyyy-MM-dd")
+
+                @if (Activity.Deadline is not null)
+                {
+                    <span class="ms-2 text-warning-emphasis">
+                        <i class="bi bi-clock me-1"></i>
+                        Deadline: @Activity.Deadline.Value.ToString("yyyy-MM-dd")
+                    </span>
+                }
+            </div>
+        </div>
+
+        <div class="d-flex align-items-center gap-2 flex-shrink-0">
+            @if (Activity.ShowSubmissionButton)
+            {
+                <button class="btn btn-success-subtle text-success rounded-3">
+                    <i class="bi bi-eye me-2"></i>
+                    Se inlämningar
+                </button>
+            }
+
+            <button class="btn btn-link text-primary p-0">
+                <i class="bi bi-pencil-square fs-5"></i>
+            </button>
+
+            <button class="btn btn-link text-danger p-0">
+                <i class="bi bi-trash fs-5"></i>
+            </button>
+        </div>
+    </div>
+
+    <hr />
+
+    <div class="small text-secondary fw-semibold mb-2">Dokument</div>
+
+    @if (Activity.Documents.Any())
+    {
+        <div class="d-flex flex-column gap-2">
+            @foreach (var document in Activity.Documents)
+            {
+                <ModuleDocumentItem Document="document" />
+            }
+        </div>
+    }
+
+    <button class="btn btn-link text-decoration-none px-0 mt-2">
+        <i class="bi bi-plus-circle me-1"></i>
+        Lägg till dokument
+    </button>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public ModuleActivityModel Activity { get; set; } = new();
+
+    private string GetTypeLabel() => Activity.Type switch
+    {
+        ModuleActivityType.Lecture => "Föreläsning",
+        ModuleActivityType.Exercise => "Övning",
+        ModuleActivityType.Assignment => "Inlämning",
+        _ => "Aktivitet"
+    };
+
+    private string GetBadgeClass() => Activity.Type switch
+    {
+        ModuleActivityType.Lecture => "badge rounded-pill text-primary bg-primary-subtle",
+        ModuleActivityType.Exercise => "badge rounded-pill text-primary bg-primary-subtle",
+        ModuleActivityType.Assignment => "badge rounded-pill text-primary bg-primary-subtle",
+        _ => "badge rounded-pill text-secondary bg-light"
+    };
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleCard.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleCard.razor
@@ -1,0 +1,79 @@
+﻿<div class="accordion-item border-0 shadow-sm rounded-4 overflow-hidden mb-3">
+    <h2 class="accordion-header" id="@($"heading-{Module.Id}")">
+        <button class="accordion-button collapsed px-4 py-3"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="@($"#collapse-{Module.Id}")"
+                aria-expanded="false"
+                aria-controls="@($"collapse-{Module.Id}")">
+
+            <div class="d-flex justify-content-between align-items-center w-100 me-3">
+                <div class="d-flex align-items-center gap-3 min-w-0">
+                    <div class="d-flex align-items-center justify-content-center rounded-circle bg-primary-subtle flex-shrink-0"
+                         style="width: 3rem; height: 3rem;">
+                        <i class="bi bi-stack text-primary"></i>
+                    </div>
+
+                    <div class="min-w-0 text-start">
+                        <div class="fw-semibold fs-5 text-dark">@Module.Title</div>
+                        <div class="text-secondary">
+                            @Module.StartDate.ToString("yyyy-MM-dd") - @Module.EndDate.ToString("yyyy-MM-dd")
+                        </div>
+                    </div>
+                </div>
+
+                <div class="text-end flex-shrink-0 me-3" style="min-width: 140px;">
+                    <div class="fw-semibold text-dark">@Module.Progress% avklarat</div>
+                    <div class="progress mt-1 rounded-pill" style="height: 0.5rem;">
+                        <div class="progress-bar rounded-pill" style="width:@($"{Module.Progress}%")"></div>
+                    </div>
+                </div>
+            </div>
+        </button>
+    </h2>
+
+    <div id="@($"collapse-{Module.Id}")"
+         class="accordion-collapse collapse @(Module.IsExpanded ? "show" : "")"
+         aria-labelledby="@($"heading-{Module.Id}")">
+        <div class="accordion-body p-4">
+            <div class="d-flex justify-content-between align-items-center gap-3 flex-wrap mb-4">
+                <div class="text-secondary fs-6">
+                    @if (!string.IsNullOrWhiteSpace(Module.Description))
+                    {
+                        @Module.Description
+                    }
+                </div>
+
+                <div class="d-flex gap-2 flex-shrink-0">
+                    <button class="btn btn-primary-subtle text-primary rounded-3">
+                        <i class="bi bi-pencil-square me-2"></i>
+                        Redigera
+                    </button>
+
+                    <button class="btn btn-danger-subtle text-danger rounded-3">
+                        <i class="bi bi-trash me-2"></i>
+                        Ta bort
+                    </button>
+                </div>
+            </div>
+
+            <h3 class="h5 fw-semibold mb-3">Aktiviteter</h3>
+
+            <div class="d-flex flex-column gap-3">
+                @foreach (var activity in Module.Activities)
+                {
+                    <ModuleActivityItem Activity="activity" />
+                }
+            </div>
+
+            <button class="btn btn-outline-secondary w-100 border-dashed rounded-3 mt-3">
+                <i class="bi bi-plus-circle me-2"></i>
+                Lägg till aktivitet
+            </button>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public ModuleModel Module { get; set; } = new();
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleDocumentItem.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleDocumentItem.razor
@@ -1,0 +1,12 @@
+﻿<div class="d-flex justify-content-between align-items-center">
+    <div class="d-flex align-items-center gap-2 min-w-0">
+        <i class="bi bi-file-earmark-text text-secondary"></i>
+        <span class="text-truncate">@Document.FileName</span>
+    </div>
+
+    <span class="text-secondary small ms-3 flex-shrink-0">@Document.FileSize</span>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public ModuleDocumentModel Document { get; set; } = new();
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleProgressList.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleProgressList.razor
@@ -1,0 +1,21 @@
+﻿<div>
+    <h4 class="h5 fw-semibold mb-3">Moduler</h4>
+
+    @foreach (var module in Modules)
+    {
+        <div class="mb-3">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <span class="fs-6">@module.Name</span>
+                <span class="text-secondary small">@module.Progress%</span>
+            </div>
+
+            <div class="progress rounded-pill" style="height: 0.6rem;">
+                <div class="progress-bar rounded-pill" style="width:@($"{module.Progress}%")"></div>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public List<ModuleProgressModel> Modules { get; set; } = [];
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModulesSection.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModulesSection.razor
@@ -1,0 +1,19 @@
+﻿<div class="d-flex justify-content-between align-items-center mb-4">
+    <h2 class="h3 mb-0 fw-semibold">Moduler</h2>
+
+    <button class="btn btn-primary rounded-3">
+        <i class="bi bi-plus-circle me-2"></i>
+        Lägg till modul
+    </button>
+</div>
+
+<div class="accordion" id="modulesAccordion">
+    @foreach (var module in Modules)
+    {
+        <ModuleCard Module="module" />
+    }
+</div>
+
+@code {
+    [Parameter] public List<ModuleModel> Modules { get; set; } = [];
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/ActivityListItem.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/ActivityListItem.razor
@@ -1,0 +1,39 @@
+﻿<div class="d-flex align-items-start gap-3 px-4 py-3 border-bottom">
+    <div class="@GetIconWrapperClass() d-flex align-items-center justify-content-center rounded-circle flex-shrink-0"
+         style="width: 2.75rem; height: 2.75rem;">
+        <i class="@($"{GetIcon()} {GetIconColorClass()}")"></i>
+    </div>
+
+    <div class="min-w-0">
+        <div class="fw-medium">@Activity.Title</div>
+        <div class="text-secondary small mt-1">@Activity.Time</div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public ActivityModel Activity { get; set; } = new();
+
+    private string GetIcon() => Activity.Type switch
+    {
+        ActivityType.Submission => "bi bi-file-earmark-check",
+        ActivityType.Document => "bi bi-file-earmark-text",
+        ActivityType.Module => "bi bi-box-seam",
+        _ => "bi bi-circle"
+    };
+
+    private string GetIconWrapperClass() => Activity.Type switch
+    {
+        ActivityType.Submission => "bg-success-subtle",
+        ActivityType.Document => "bg-primary-subtle",
+        ActivityType.Module => "bg-info-subtle",
+        _ => "bg-light"
+    };
+
+    private string GetIconColorClass() => Activity.Type switch
+    {
+        ActivityType.Submission => "text-success fs-5",
+        ActivityType.Document => "text-primary fs-5",
+        ActivityType.Module => "text-info fs-5",
+        _ => "text-secondary fs-5"
+    };
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/CourseProgressCard.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/CourseProgressCard.razor
@@ -1,0 +1,22 @@
+﻿@using LMS.Blazor.Client.Components.TeacherCourseOverview.ModulesComponents
+<div class="card border-0 shadow-sm rounded-4 h-100">
+    <div class="card-body p-4">
+        <h3 class="h4 fw-semibold mb-4">Kursframsteg</h3>
+
+        <div class="d-flex align-items-baseline gap-2 mb-3">
+            <span class="fs-2 fw-bold text-primary">@Progress%</span>
+            <span class="text-secondary fs-5">genomfört i genomsnitt</span>
+        </div>
+
+        <div class="progress mb-4 rounded-pill" role="progressbar" aria-valuenow="@Progress" aria-valuemin="0" aria-valuemax="100" style="height: 0.9rem;">
+            <div class="progress-bar rounded-pill" style="width:@($"{Progress}%")"></div>
+        </div>
+
+        <ModuleProgressList Modules="Modules" />
+    </div>
+</div>
+
+@code {
+    [Parameter] public int Progress { get; set; }
+    [Parameter] public List<ModuleProgressModel> Modules { get; set; } = [];
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/CourseStatisticsCard.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/CourseStatisticsCard.razor
@@ -1,0 +1,43 @@
+﻿<div class="card border-0 shadow-sm rounded-4 h-100">
+    <div class="card-body p-4">
+        <h3 class="h4 fw-semibold mb-4">Kursstatistik</h3>
+
+        <div class="row g-3">
+            <div class="col-12 col-sm-6">
+                <StatisticTile Title="Moduler"
+                               Value="@Statistics.Modules"
+                               Icon="bi bi-stack"
+                               BackgroundClass="bg-primary-subtle"
+                               IconColorClass="text-primary" />
+            </div>
+
+            <div class="col-12 col-sm-6">
+                <StatisticTile Title="Aktiviteter"
+                               Value="@Statistics.Activities"
+                               Icon="bi bi-calendar-event"
+                               BackgroundClass="bg-success-subtle"
+                               IconColorClass="text-success" />
+            </div>
+
+            <div class="col-12 col-sm-6">
+                <StatisticTile Title="Studenter"
+                               Value="@Statistics.Students"
+                               Icon="bi bi-people"
+                               BackgroundClass="bg-info-subtle"
+                               IconColorClass="text-info" />
+            </div>
+
+            <div class="col-12 col-sm-6">
+                <StatisticTile Title="Inlämningar"
+                               Value="@Statistics.Submissions"
+                               Icon="bi bi-file-earmark-text"
+                               BackgroundClass="bg-warning-subtle"
+                               IconColorClass="text-warning-emphasis" />
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public CourseStatisticsModel Statistics { get; set; } = new();
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/RecentActivitiesCard.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/RecentActivitiesCard.razor
@@ -1,0 +1,28 @@
+﻿<div class="card border-0 shadow-sm rounded-4">
+    <div class="card-body p-0">
+        <div class="d-flex justify-content-between align-items-center px-4 py-3 border-bottom">
+            <h3 class="h4 fw-semibold mb-0">Senaste aktiviteter</h3>
+            <a href="#" class="text-decoration-none fw-medium">
+                Visa alla <i class="bi bi-chevron-right ms-1"></i>
+            </a>
+        </div>
+
+        @if (!Activities.Any())
+        {
+            <div class="p-4 text-secondary">
+                Inga aktiviteter
+            </div>
+        }
+        else
+        {
+            @foreach (var activity in Activities)
+            {
+                <ActivityListItem Activity="activity" />
+            }
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public List<ActivityModel> Activities { get; set; } = [];
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/StatisticTile.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/StatisticTile.razor
@@ -1,0 +1,21 @@
+﻿<div class="rounded-4 p-3 h-100 @BackgroundClass">
+    <div class="d-flex align-items-center gap-3">
+        <div class="d-flex align-items-center justify-content-center rounded-circle bg-white bg-opacity-75 flex-shrink-0"
+             style="width: 3rem; height: 3rem;">
+            <i class="@($"{Icon} {IconColorClass} fs-4")"></i>
+        </div>
+
+        <div>
+            <div class="text-secondary small">@Title</div>
+            <div class="fs-3 fw-bold lh-sm">@Value</div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Title { get; set; } = "";
+    [Parameter] public int Value { get; set; }
+    [Parameter] public string Icon { get; set; } = "";
+    [Parameter] public string BackgroundClass { get; set; } = "bg-light";
+    [Parameter] public string IconColorClass { get; set; } = "text-primary";
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/StudentComponents/StudentRow.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/StudentComponents/StudentRow.razor
@@ -1,0 +1,39 @@
+﻿<tr>
+    <td class="px-4 py-4 fw-semibold fs-6">@Student.Name</td>
+
+    <td class="px-4 py-4 fs-6">@Student.Email</td>
+
+    <td class="px-4 py-4" style="min-width: 220px;">
+        <div class="d-flex align-items-center gap-3">
+            <div class="progress flex-grow-1 rounded-pill" style="height: 0.8rem;">
+                <div class="progress-bar rounded-pill"
+                     role="progressbar"
+                     style="width:@($"{Student.ProgressPercent}%")"
+                     aria-valuenow="@Student.ProgressPercent"
+                     aria-valuemin="0"
+                     aria-valuemax="100">
+                </div>
+            </div>
+
+            <span class="text-secondary fs-6">@Student.ProgressPercent%</span>
+        </div>
+    </td>
+
+    <td class="px-4 py-4 fs-6">@Student.LastActive.ToString("yyyy-MM-dd")</td>
+
+    <td class="px-4 py-4 text-end">
+        <div class="d-inline-flex align-items-center gap-3">
+            <button type="button" class="btn btn-link text-decoration-none fw-semibold p-0">
+                Visa detaljer
+            </button>
+
+            <button type="button" class="btn btn-link text-danger p-0">
+                <i class="bi bi-x-circle fs-4"></i>
+            </button>
+        </div>
+    </td>
+</tr>
+
+@code {
+    [Parameter, EditorRequired] public StudentListItemModel Student { get; set; } = new();
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/StudentComponents/StudentsSection.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/StudentComponents/StudentsSection.razor
@@ -1,0 +1,33 @@
+﻿<div class="d-flex justify-content-between align-items-center mb-4">
+    <h4 class="h4 mb-0 fw-semibold">Studenter</h4>
+
+    <button class="btn btn-primary rounded-3">
+        <i class="bi bi-plus-circle me-2"></i>
+        Lägg till student
+    </button>
+</div>
+
+<div class="card border-0 shadow-sm rounded-4 overflow-hidden">
+    <StudentsToolbar SearchText="@SearchText" SearchTextChanged="OnSearchTextChanged" />
+
+    <StudentsTable Students="FilteredStudents" />
+</div>
+
+@code {
+    [Parameter] public List<StudentListItemModel> Students { get; set; } = [];
+
+    private string SearchText { get; set; } = string.Empty;
+
+    private IEnumerable<StudentListItemModel> FilteredStudents =>
+        string.IsNullOrWhiteSpace(SearchText)
+            ? Students
+            : Students.Where(s =>
+                s.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase) ||
+                s.Email.Contains(SearchText, StringComparison.OrdinalIgnoreCase));
+
+    private Task OnSearchTextChanged(string value)
+    {
+        SearchText = value;
+        return Task.CompletedTask;
+    }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/StudentComponents/StudentsTable.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/StudentComponents/StudentsTable.razor
@@ -1,0 +1,32 @@
+﻿@if (Students.Any())
+{
+    <div class="table-responsive">
+        <table class="table align-middle mb-0">
+            <thead class="text-uppercase text-secondary small">
+                <tr>
+                    <th class="px-4 py-3 fw-semibold">Namn</th>
+                    <th class="px-4 py-3 fw-semibold">Email</th>
+                    <th class="px-4 py-3 fw-semibold">Framsteg</th>
+                    <th class="px-4 py-3 fw-semibold">Senast aktiv</th>
+                    <th class="px-4 py-3 fw-semibold text-end"></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var student in Students)
+                {
+                    <StudentRow Student="student" />
+                }
+            </tbody>
+        </table>
+    </div>
+}
+else
+{
+    <div class="p-4 text-secondary">
+        Inga studenter hittades.
+    </div>
+}
+
+@code {
+    [Parameter] public IEnumerable<StudentListItemModel> Students { get; set; } = [];
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/StudentComponents/StudentsToolbar.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/StudentComponents/StudentsToolbar.razor
@@ -1,0 +1,20 @@
+﻿<div class="p-4 border-bottom">
+    <div class="row">
+        <div class="col-12 col-md-5 col-lg-4">
+            <input class="form-control form-control-lg rounded-3"
+                   placeholder="Sök efter student..."
+                   value="@SearchText"
+                   @oninput="HandleInput" />
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public string SearchText { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> SearchTextChanged { get; set; }
+
+    private async Task HandleInput(ChangeEventArgs e)
+    {
+        await SearchTextChanged.InvokeAsync(e.Value?.ToString() ?? string.Empty);
+    }
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherDashboard/OverviewCourseRow.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherDashboard/OverviewCourseRow.razor
@@ -3,7 +3,7 @@
         <div class="d-flex justify-content-between">
             <div class="w-50 d-flex flex-column">
                 <div>
-                    <a href="#" class="text-decoration-none">@Course.Name</a>
+                    <a href="CourseOverviewTeacher" class="text-decoration-none">@Course.Name</a>
                 </div>
                 <div class="text-secondary">
                     @Course.StartDateStr - @Course.EndDateStr

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherDashboard/TeacherAllCoursesTableRow.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherDashboard/TeacherAllCoursesTableRow.razor
@@ -5,7 +5,7 @@
         <td>@Course.NumberOfStudents</td>
         <td>@Course.Modules.Count</td>
         <td class="text-end">
-            <a class="text-decoration-none" href="#">Visa</a>
+            <a class="text-decoration-none" href="CourseOverviewTeacher">Visa</a>
             <a class="ms-2 text-decoration-none pe-2" href="#">Redigera</a>
         </td>
     </tr>

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
@@ -1,6 +1,10 @@
 ﻿@page "/CourseOverviewTeacher"
 
 @using LMS.Blazor.Client.Components.TeacherCourseOverview
+@using LMS.Blazor.Client.Components.TeacherCourseOverview.ModulesComponents
+@using LMS.Blazor.Client.Components.TeacherCourseOverview.OverviewComponents
+@using LMS.Blazor.Client.Components.TeacherCourseOverview.StudentComponents
+
 <CourseHeader Title="Lexicon LTU"
               Description="En omfattande utbildning i modern webbutveckling med fokus på JavaScript och React."
               StartDate="@(new DateTime(2023, 8, 15))"
@@ -10,23 +14,193 @@
               EditButtonText="Redigera kurs"
               OnEditClicked="HandleEditCourse" />
 
-<CourseTabs Tabs="_tabs" />
+<CourseTabs Tabs="_tabs" OnTabChanged="HandleTabChanged" />
+
+@if (_activeTab == "Översikt")
+{
+    <div class="container-fluid px-0">
+        <div class="row g-4 mb-4">
+            <div class="col-12 col-xl-6">
+                <CourseProgressCard Progress="35" Modules="_moduleProgress" />
+            </div>
+
+            <div class="col-12 col-xl-6">
+                <CourseStatisticsCard Statistics="_statistics" />
+            </div>
+        </div>
+
+        <RecentActivitiesCard Activities="_activities" />
+    </div>
+}
+else if (_activeTab == "Moduler")
+{
+    <ModulesSection Modules="_courseModules" />
+}
+else if (_activeTab == "Inlämningar")
+{
+    <div class="alert alert-light border rounded-4">
+        Inlämningar kommer här.
+    </div>
+}
+else if (_activeTab == "Studenter")
+{
+    <StudentsSection Students="_students" />
+}
+else if (_activeTab == "Dokument")
+{
+    <div class="alert alert-light border rounded-4">
+        Dokument kommer här.
+    </div>
+}
 
 @code {
+    private string _activeTab = "Översikt";
+
     private List<CourseTabs.CourseTabItem> _tabs = new()
     {
-        new() { Label = "Översikt", Url = "/courses/1/overview", IsActive = true },
-        new() { Label = "Moduler", Url = "/courses/1/modules" },
-        new() { Label = "Inlämningar", Url = "/courses/1/assignments" },
-        new() { Label = "Studenter", Url = "/courses/1/students" },
-        new() { Label = "Dokument", Url = "/courses/1/documents" }
+        new() { Label = "Översikt", IsActive = true },
+        new() { Label = "Moduler" },
+        new() { Label = "Inlämningar" },
+        new() { Label = "Studenter" },
+        new() { Label = "Dokument" }
     };
-}
-@code {
+
+    private List<ModuleProgressModel> _moduleProgress = new()
+    {
+        new() { Name = "HTML & CSS", Progress = 100 },
+        new() { Name = "JavaScript", Progress = 60 },
+        new() { Name = "React", Progress = 20 }
+    };
+
+    private CourseStatisticsModel _statistics = new()
+    {
+        Modules = 3,
+        Activities = 11,
+        Students = 5,
+        Submissions = 3
+    };
+
+    private List<ActivityModel> _activities = new()
+    {
+        new()
+        {
+            Title = "Anna Andersson lämnade in uppgift \"JavaScript applikation\"",
+            Time = "2 timmar sedan",
+            Type = ActivityType.Submission
+        },
+        new()
+        {
+            Title = "Nytt material uppladdat: \"React Komponenter Övningar\"",
+            Time = "4 timmar sedan",
+            Type = ActivityType.Document
+        },
+        new()
+        {
+            Title = "Modul \"React\" startade",
+            Time = "1 dag sedan",
+            Type = ActivityType.Module
+        }
+    };
+
+    private List<ModuleModel> _courseModules = new()
+    {
+        new()
+        {
+            Title = "HTML & CSS",
+            Description = "Grundläggande webbutveckling med HTML5 och CSS3",
+            StartDate = new DateTime(2023, 8, 15),
+            EndDate = new DateTime(2023, 9, 1),
+            Progress = 100,
+            IsExpanded = true,
+            Activities =
+            [
+                new()
+                {
+                    Title = "Introduktion till HTML",
+                    Type = ModuleActivityType.Lecture,
+                    Date = new DateTime(2023, 8, 15),
+                    Documents =
+                    [
+                        new() { FileName = "HTML Grunderna.pdf", FileSize = "1.5 MB" },
+                        new() { FileName = "Taggstruktur.pdf", FileSize = "0.8 MB" }
+                    ]
+                },
+                new()
+                {
+                    Title = "Skapa en webbsida",
+                    Type = ModuleActivityType.Exercise,
+                    Date = new DateTime(2023, 8, 16),
+                    Documents =
+                    [
+                        new() { FileName = "Övningsuppgift.pdf", FileSize = "0.5 MB" }
+                    ]
+                }
+            ]
+        },
+        new()
+        {
+            Title = "JavaScript",
+            StartDate = new DateTime(2023, 9, 2),
+            EndDate = new DateTime(2023, 9, 20),
+            Progress = 60,
+            IsExpanded = false
+        },
+        new()
+        {
+            Title = "React",
+            StartDate = new DateTime(2023, 9, 21),
+            EndDate = new DateTime(2023, 10, 15),
+            Progress = 20,
+            IsExpanded = false
+        }
+    };
+
+    private List<StudentListItemModel> _students = new()
+    {
+        new()
+        {
+            Name = "Anna Andersson",
+            Email = "anna.andersson@example.com",
+            ProgressPercent = 78,
+            LastActive = new DateTime(2023, 9, 10)
+        },
+        new()
+        {
+            Name = "Erik Eriksson",
+            Email = "erik.eriksson@example.com",
+            ProgressPercent = 65,
+            LastActive = new DateTime(2023, 9, 9)
+        },
+        new()
+        {
+            Name = "Maria Svensson",
+            Email = "maria.svensson@example.com",
+            ProgressPercent = 92,
+            LastActive = new DateTime(2023, 9, 11)
+        },
+        new()
+        {
+            Name = "Johan Nilsson",
+            Email = "johan.nilsson@example.com",
+            ProgressPercent = 45,
+            LastActive = new DateTime(2023, 9, 8)
+        },
+        new()
+        {
+            Name = "Sara Lindberg",
+            Email = "sara.lindberg@example.com",
+            ProgressPercent = 83,
+            LastActive = new DateTime(2023, 9, 10)
+        }
+    };
+
     private void HandleEditCourse()
     {
         // Navigate to edit page or open modal
     }
 
-
+    private void HandleTabChanged(string tabLabel)
+    {
+        _activeTab = tabLabel;
+    }
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
@@ -1,0 +1,32 @@
+﻿@page "/CourseOverviewTeacher"
+
+@using LMS.Blazor.Client.Components.TeacherCourseOverview
+<CourseHeader Title="Lexicon LTU"
+              Description="En omfattande utbildning i modern webbutveckling med fokus på JavaScript och React."
+              StartDate="@(new DateTime(2023, 8, 15))"
+              EndDate="@(new DateTime(2023, 12, 15))"
+              BackUrl="/dashboard"
+              BackText="Tillbaka till dashboard"
+              EditButtonText="Redigera kurs"
+              OnEditClicked="HandleEditCourse" />
+
+<CourseTabs Tabs="_tabs" />
+
+@code {
+    private List<CourseTabs.CourseTabItem> _tabs = new()
+    {
+        new() { Label = "Översikt", Url = "/courses/1/overview", IsActive = true },
+        new() { Label = "Moduler", Url = "/courses/1/modules" },
+        new() { Label = "Inlämningar", Url = "/courses/1/assignments" },
+        new() { Label = "Studenter", Url = "/courses/1/students" },
+        new() { Label = "Dokument", Url = "/courses/1/documents" }
+    };
+}
+@code {
+    private void HandleEditCourse()
+    {
+        // Navigate to edit page or open modal
+    }
+
+
+}

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
@@ -9,7 +9,7 @@
               Description="En omfattande utbildning i modern webbutveckling med fokus på JavaScript och React."
               StartDate="@(new DateTime(2023, 8, 15))"
               EndDate="@(new DateTime(2023, 12, 15))"
-              BackUrl="/dashboard"
+              BackUrl="/"
               BackText="Tillbaka till dashboard"
               EditButtonText="Redigera kurs"
               OnEditClicked="HandleEditCourse" />


### PR DESCRIPTION
Structured course overview page with tab-based navigation and reusable components. Built for the Teacher view. 

**Changes**
Implemented tab navigation to switch between:
-Översikt
-Moduler
-Studenter
-Inlämningar
-Dokument

*I have not implemented design for tabs: Inlämningar and Dokument

You can navigate to the course overview page from teacher dashboard by clicking on a course. 
Right now its only static data so no data is fetched from API.  

Overview tab:
<img width="2524" height="1371" alt="image" src="https://github.com/user-attachments/assets/ecb8b387-a833-40ad-aa26-51c942a6c7b9" />

Modules tab: (Closed modules)
<img width="2443" height="1133" alt="image" src="https://github.com/user-attachments/assets/859e3a48-0642-43d2-87fa-3c1c78241adc" />

Open modules:
<img width="2467" height="1131" alt="image" src="https://github.com/user-attachments/assets/0e59145a-432b-4129-a03a-d5aa06f5ec88" />

<img width="2305" height="1237" alt="image" src="https://github.com/user-attachments/assets/618d973d-fc80-4da0-8eb1-e449ef43b970" />

