### PR TITLE
handling module overlap/domain exceptions via problem+json middleware

### DIFF
--- a/LMS.API/Extensions/ExceptionMiddlewareExtetensions.cs
+++ b/LMS.API/Extensions/ExceptionMiddlewareExtetensions.cs
@@ -14,29 +14,31 @@ public static class ExceptionMiddlewareExtetensions
             builder.Run(async context =>
             {
                 var contextFeature = context.Features.Get<IExceptionHandlerFeature>();
-                if (contextFeature != null)
+                var exception = contextFeature?.Error;
+
+                var problemDetailsFactory = app.Services.GetRequiredService<ProblemDetailsFactory>();
+
+                var (statusCode, title, detail) = exception switch
                 {
-                    var problemDetailsFactory = app.Services.GetRequiredService<ProblemDetailsFactory>();
-                    var exception = contextFeature.Error;
+                    BadRequestException badRequest => (StatusCodes.Status400BadRequest, badRequest.Title, badRequest.Message),
+                    NotFoundException notFound => (StatusCodes.Status404NotFound, notFound.Title, notFound.Message),
+                    TokenValidationException tokenEx => (tokenEx.StatusCode, "Unauthorized", tokenEx.Message),
+                    DomainException domainEx => (StatusCodes.Status400BadRequest, domainEx.Title, domainEx.Message),
+                    null => (StatusCodes.Status500InternalServerError, "Internal Server Error", "An unexpected error occurred."),
+                    _ => (StatusCodes.Status500InternalServerError, "Internal Server Error", exception.Message)
+                };
 
-                    var (statusCode, title) = exception switch
-                    {
-                        BadRequestException => (StatusCodes.Status400BadRequest, (exception as BadRequestException)!.Title),
-                        NotFoundException => (StatusCodes.Status404NotFound, (exception as NotFoundException)!.Title),
-                        TokenValidationException tokenEx => (tokenEx.StatusCode, "Unauthorized"),
-                        _ => (StatusCodes.Status500InternalServerError, "Internal Server Error")
-                    };
+                var problemDetails = problemDetailsFactory.CreateProblemDetails(
+                    context,
+                    statusCode: statusCode,
+                    title: title,
+                    detail: detail,
+                    instance: context.Request.Path);
 
-                    var problemDetails = problemDetailsFactory.CreateProblemDetails(
-                        context,
-                        statusCode,
-                        title: title,
-                        detail: exception.Message,
-                        instance: context.Request.Path);
+                context.Response.StatusCode = statusCode;
+                context.Response.ContentType = "application/problem+json";
+                await context.Response.WriteAsJsonAsync(problemDetails);
 
-                    context.Response.StatusCode = statusCode;
-                    await context.Response.WriteAsJsonAsync(problemDetails);
-                }
             });
         });
     }

--- a/LMS.Services/ModuleService.cs
+++ b/LMS.Services/ModuleService.cs
@@ -145,7 +145,7 @@ public class ModuleService : IModuleService
 
         if (hasOverlap)
         {
-            throw new BadRequestException("Module dates overlap with another module in this course.");
+            throw new BadRequestException("Moduldatum överlappar med en annan modul i den här kursen.");
         }
     }
 }


### PR DESCRIPTION
Closes the issue https://github.com/LexiconNETGrupp2/LMS/issues/67.

Fixed API exception handling for overlapping module creation: domain errors now consistently return application/problem+json (instead of crashing/500), the frontend shows a clear user-facing error message.