### PR TITLE
Added endpoint for retrieving students by course

### DIFF
--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -11,4 +11,5 @@ public interface ICourseRepository : IRepositoryBase<Course>
     Task<Course?> GetCourseByIdTracked(Guid id, CancellationToken token);
     Task<Course?> GetCourseFromUserId(Guid userId, CancellationToken token);
     Task<CourseParticipantsReadModel?> GetCourseParticipantsByUserId(Guid userId, CancellationToken token);
+    Task<IReadOnlyCollection<CourseStudentDto>> GetStudentsByCourseId(Guid courseId, CancellationToken token);
 }

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -2,6 +2,7 @@ using Domain.Contracts.Repositories;
 using Domain.Contracts.Repositories.Models;
 using Domain.Models.Entities;
 using LMS.Infractructure.Data;
+using LMS.Shared.Constants;
 using LMS.Shared.DTOs.CourseDtos;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -123,5 +124,32 @@ public class CourseRepository : RepositoryBase<Course>, ICourseRepository
                             RoleName = role.Name
                         })
                         .ToListAsync(token);
+    }
+
+    public async Task<IReadOnlyCollection<CourseStudentDto>> GetStudentsByCourseId(Guid courseId, CancellationToken token)
+    {
+        var students = await (
+            from course in _context.Courses.AsNoTracking()
+            where course.Id == courseId
+
+            from student in course.Students
+
+            join userRole in _context.Set<IdentityUserRole<string>>().AsNoTracking()
+                on student.Id equals userRole.UserId
+
+            join role in _context.Roles.AsNoTracking()
+                on userRole.RoleId equals role.Id
+
+            where role.Name == RolesNames.Student
+
+            select new CourseStudentDto
+            {
+                Id = student.Id,
+                FullName = (student.FirstName + " " + student.LastName).Trim(),
+                Email = student.Email ?? string.Empty
+            }
+        ).ToListAsync(token);
+
+        return students;
     }
 }

--- a/LMS.Presentation/Controllers/CoursesController.cs
+++ b/LMS.Presentation/Controllers/CoursesController.cs
@@ -129,7 +129,7 @@ public class CoursesController : ControllerBase
     [SwaggerOperation(
     Summary = "Get participants in the current user's course",
     Description = "Retrieves the participants for the course that the currently authenticated user belongs to."
-)]
+    )]
     [SwaggerResponse(StatusCodes.Status200OK)]
     [SwaggerResponse(StatusCodes.Status401Unauthorized)]
     [SwaggerResponse(StatusCodes.Status404NotFound)]
@@ -145,6 +145,20 @@ public class CoursesController : ControllerBase
             return NotFound();
 
         return Ok(dto);
+    }
+
+    [HttpGet("{id:guid}/students")]
+    [Authorize(Roles = RolesNames.Teacher)]
+    [SwaggerOperation(
+    Summary = "Get students in the current course",
+    Description = "Retrieves the students for the course. Require Teacher role"
+    )]
+    [SwaggerResponse(StatusCodes.Status200OK)]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetCourseStudents(Guid id, CancellationToken token)
+    {
+        var students = await _serviceManager.CourseService.GetStudentsByCourseId(id, token);
+        return Ok(students);
     }
 
     private bool IsStudent()

--- a/LMS.Presentation/Controllers/CoursesController.cs
+++ b/LMS.Presentation/Controllers/CoursesController.cs
@@ -126,6 +126,13 @@ public class CoursesController : ControllerBase
     }
 
     [HttpGet("me/participants")]
+    [SwaggerOperation(
+    Summary = "Get participants in the current user's course",
+    Description = "Retrieves the participants for the course that the currently authenticated user belongs to."
+)]
+    [SwaggerResponse(StatusCodes.Status200OK)]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized)]
+    [SwaggerResponse(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetMyCourseParticipants(CancellationToken token)
     {
         var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -149,4 +149,9 @@ public class CourseService : ICourseService
             return false;
         }
     }
+
+    public async Task<IReadOnlyCollection<CourseStudentDto>> GetStudentsByCourseId(Guid courseId, CancellationToken token)
+    {
+        return await _uow.CourseRepository.GetStudentsByCourseId(courseId, token);
+    }
 }

--- a/LMS.Shared/DTOs/CourseDtos/CourseStudentDto.cs
+++ b/LMS.Shared/DTOs/CourseDtos/CourseStudentDto.cs
@@ -1,0 +1,10 @@
+﻿
+namespace LMS.Shared.DTOs.CourseDtos;
+
+public class CourseStudentDto
+{
+    public string Id { get; init; } = string.Empty;
+    public string FullName { get; init; } = string.Empty;
+    public string Email { get; init; } = string.Empty;
+}
+

--- a/LMS.Test/Controllers/CoursesControllerTest.cs
+++ b/LMS.Test/Controllers/CoursesControllerTest.cs
@@ -256,6 +256,51 @@ public class CoursesControllerTest
         Assert.Equal(expectedStatusCode, statusResult.StatusCode);
     }
 
+    [Fact]
+    [Trait("Layer", "Controller")]
+    public async Task GetCourseStudents_WhenCalled_ReturnsOkWithStudents()
+    {
+        // Arrange
+        var ct = CancellationToken.None;
+        var courseId = Guid.NewGuid();
+
+        IReadOnlyCollection<CourseStudentDto> expectedStudents =
+        [
+            new CourseStudentDto
+        {
+            Id = "student-1",
+            FullName = "Alice Andersson",
+            Email = "alice@example.com"
+        },
+        new CourseStudentDto
+        {
+            Id = "student-2",
+            FullName = "Bob Berg",
+            Email = "bob@example.com"
+        }
+        ];
+
+        var courseServiceMock = new Mock<ICourseService>();
+        courseServiceMock
+            .Setup(s => s.GetStudentsByCourseId(courseId, ct))
+            .ReturnsAsync(expectedStudents);
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.Role, RolesNames.Teacher),
+    ], "TestAuthType"));
+
+        var controller = CreateController(courseServiceMock, principal);
+
+        // Act
+        var result = await controller.GetCourseStudents(courseId, ct);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(expectedStudents, okResult.Value);
+        courseServiceMock.Verify(s => s.GetStudentsByCourseId(courseId, ct), Times.Once);
+    }
+
     private static CoursesController CreateController(
         Mock<ICourseService> courseServiceMock,
         ClaimsPrincipal? user = null)

--- a/Service.Contracts/ICourseService.cs
+++ b/Service.Contracts/ICourseService.cs
@@ -11,4 +11,5 @@ public interface ICourseService
     Task<bool> UpdateCourse(Guid id, UpdateCourseDto updateCourseDto, CancellationToken token);
     Task<bool> DeleteCourse(Guid id, CancellationToken token);
     Task<CourseParticipantsDto?> GetCourseParticipantsByUserId(Guid id, CancellationToken token);
+    Task<IReadOnlyCollection<CourseStudentDto>> GetStudentsByCourseId(Guid courseId, CancellationToken token);
 }


### PR DESCRIPTION
A new endpoint for fetching students belonging to a specific course.

**Changes**
-New endpoint: GET /api/courses/{id}/students
-Returns a list of students for a given course
-Only accessible to users with the Teacher role
-Added a lightweight DTO (CourseStudentDto) containing only (Id, FullName, Email)

**Tests**
Added controller test verifying:
-GetCourseStudents_WhenCalled_ReturnsOkWithStudents
-200 OK is returned