### PR TITLE
Always redirect to login page when logging out

### DIFF
--- a/LMS.Blazor/LMS.Blazor.Client/Layout/MainLayout.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Layout/MainLayout.razor
@@ -50,7 +50,6 @@
 
                         <form action="Account/Logout" method="post" class="top-logout-form">
                             <AntiforgeryToken />
-                            <input type="hidden" name="ReturnUrl" value="@currentUrl" />
                             <button type="submit" class="top-link top-logout-button">
                                 <i class="bi bi-box-arrow-right" aria-hidden="true"></i>
                                 <span>Logga ut</span>

--- a/LMS.Blazor/LMS.Blazor/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/LMS.Blazor/LMS.Blazor/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 
-namespace Microsoft.AspNetCore.Routing;
+namespace LMS.Blazor.Components.Account;
 
 internal static class IdentityComponentsEndpointRouteBuilderExtensions
 {
@@ -19,8 +19,7 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
             ClaimsPrincipal user,
             [FromServices] SignInManager<ApplicationUser> signInManager,
             [FromServices] ITokenStorage tokenStorage,
-            [FromServices] UserManager<ApplicationUser> userManager,
-            [FromForm] string returnUrl) =>
+            [FromServices] UserManager<ApplicationUser> userManager) =>
         {
             var userId = userManager.GetUserId(user);
 
@@ -28,7 +27,8 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
                 await tokenStorage.RemoveTokensAsync(userId);
 
             await signInManager.SignOutAsync();
-            return TypedResults.LocalRedirect($"~/{returnUrl}");
+
+            return TypedResults.LocalRedirect("~/Account/Login");
         });
 
         return accountGroup;


### PR DESCRIPTION
Redirect user to login page after logout.
Remove redirect url from logout form.

fixes #101 