### PR TITLE
Redigera kurser

### DIFF
--- a/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -7,6 +7,6 @@ namespace Domain.Contracts.Repositories;
 public interface ICourseRepository : IRepositoryBase<Course>
 {
     Task<PagedResult<Course>> GetAllCourses(AllCoursesParams param, CancellationToken token);
-    Task<Course?> GetCourseById(Guid id, bool trackChanges, CancellationToken token);
+    Task<Course?> GetCourseById(Guid id, bool trackChanges, CancellationToken token, bool includeAllData = true);
     Task<Course?> GetCourseFromUserId(Guid userId, bool trackChanges, CancellationToken token);
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Components/CreateCourse/CreateCourseForm.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/CreateCourse/CreateCourseForm.razor
@@ -12,8 +12,7 @@
                        class="form-control"
                        placeholder="Namnet på kursen"
                        type="text"
-                       autofocus
-                       onkeypress="return event.keyCode != 13" /> @* Disables submitting when pressing enter (KeyCode 13) *@
+                       autofocus />
             <ValidationMessage For="() => Course.Name" />
         </div>
 
@@ -76,7 +75,7 @@
             </div>
         }
         <div class="d-flex justify-content-end">
-            <button class="btn btn-outline-secondary me-3" @onclick="CancelForm">Avbryt</button>
+            <button type="button" class="btn btn-outline-secondary me-3" @onclick="CancelForm">Avbryt</button>
             <button type="submit" class="btn btn-primary float-end" disabled="@IsLoading">@(IsEditing ? "Redigera kurs" : "Skapa kurs")</button>
         </div>
     </EditForm>
@@ -104,7 +103,7 @@
     public EventCallback<Guid?> OnRemoveModule { get; set; }
 
     private async Task CreateCourse()
-    {        
+    {
         if (OnCreateCourse.HasDelegate)
             await OnCreateCourse.InvokeAsync(Course);
     }
@@ -116,9 +115,6 @@
     }
 
     private void CancelForm()
-    {
-        Console.WriteLine("Course created");
-        NavigationManager.NavigateTo("/");
-    }
+        => NavigationManager.NavigateTo("/");
     
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Components/CreateCourse/CreateCourseForm.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/CreateCourse/CreateCourseForm.razor
@@ -1,7 +1,7 @@
 ﻿@inject NavigationManager NavigationManager
 
 <div class="container bg-white py-4 rounded">
-    <h1 class="h1 fs-3 fw-bold">Skapa kurs</h1>
+    <h1 class="h1 fs-3 fw-bold">@(IsEditing ? "Redigera kurs" : "Skapa kurs")</h1>
     <EditForm FormName="CreateCourse" Model="Course" OnValidSubmit="CreateCourse" class="vstack gap-3 mt-4">
         <DataAnnotationsValidator />
 
@@ -45,38 +45,38 @@
             </div>
         </div>
 
-        <h3 class="h3 fs-5 fw-bold border-top pt-3">Lägg till moduler</h3>
-        @for (int i = 0; i < Course.Modules.Count; i++) {
-            <AddModule Module="Course.Modules[i]"
-                       OnDelete="OnRemoveModule"
-                       index="i+1"
-                       CourseStart="Course.StartDate"
-                       CourseEnd="Course.EndDate"
-                       PreviousModuleEnd="@(i > 0 ? Course.Modules[i - 1].EndDate : null)"
-                       NextModuleStart="@(i == Course.Modules.Count ? Course.Modules[i+1].StartDate : null)" />
-        }
+        @if (!IsEditing) {
+            <h3 class="h3 fs-5 fw-bold border-top pt-3">Lägg till moduler</h3>
+            @for (int i = 0; i < Course.Modules.Count; i++) {
+                <AddModule Module="Course.Modules[i]"
+                           OnDelete="OnRemoveModule"
+                           index="i+1"
+                           CourseStart="Course.StartDate"
+                           CourseEnd="Course.EndDate"
+                           PreviousModuleEnd="@(i > 0 ? Course.Modules[i - 1].EndDate : null)"
+                           NextModuleStart="@(i == Course.Modules.Count ? Course.Modules[i+1].StartDate : null)" />
+            }
+            <ValidationSummary class="alert alert-danger" />
+            @if (OverlapErrors is not null && OverlapErrors.Count > 0) {
+                <div class="alert alert-danger">
+                    <ul class="m-0">
+                        @foreach (string error in OverlapErrors) {
+                            <li>@error</li>
+                        }
+                    </ul>
+                </div>
+            }
 
-        <ValidationSummary class="alert alert-danger" />
-        @if (OverlapErrors is not null && OverlapErrors.Count > 0) {
-            <div class="alert alert-danger">
-                <ul class="m-0">
-                    @foreach (string error in OverlapErrors) {
-                        <li>@error</li>
-                    }
-                </ul>
+            <div>
+                <button type="button" class="btn btn-link text-decoration-none float-start" @onclick="AddModule">
+                    <i class="bi bi-plus-circle"></i>
+                    Lägg till modul
+                </button>
             </div>
         }
-
-        <div>
-            <button type="button" class="btn btn-link text-decoration-none float-start" @onclick="AddModule">
-                <i class="bi bi-plus-circle"></i>
-                Lägg till modul
-            </button>
-        </div>
-
         <div class="d-flex justify-content-end">
             <button class="btn btn-outline-secondary me-3" @onclick="CancelForm">Avbryt</button>
-            <button type="submit" class="btn btn-primary float-end" disabled="@IsLoading">Skapa kurs</button>
+            <button type="submit" class="btn btn-primary float-end" disabled="@IsLoading">@(IsEditing ? "Redigera kurs" : "Skapa kurs")</button>
         </div>
     </EditForm>
 </div>
@@ -90,6 +90,9 @@
 
     [Parameter]
     public bool IsLoading { get; set; }
+
+    [Parameter]
+    public bool IsEditing { get; set; }
 
     [Parameter]
     public EventCallback<CourseFormModel> OnCreateCourse { get; set; }

--- a/LMS.Blazor/LMS.Blazor.Client/Components/CreateCourse/CreateCourseForm.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/CreateCourse/CreateCourseForm.razor
@@ -12,7 +12,8 @@
                        class="form-control"
                        placeholder="Namnet på kursen"
                        type="text"
-                       autofocus />
+                       autofocus
+                       onkeypress="return event.keyCode != 13" /> @* Disables submitting when pressing enter (KeyCode 13) *@
             <ValidationMessage For="() => Course.Name" />
         </div>
 
@@ -103,7 +104,7 @@
     public EventCallback<Guid?> OnRemoveModule { get; set; }
 
     private async Task CreateCourse()
-    {
+    {        
         if (OnCreateCourse.HasDelegate)
             await OnCreateCourse.InvokeAsync(Course);
     }
@@ -115,5 +116,9 @@
     }
 
     private void CancelForm()
-        => NavigationManager.NavigateTo("/");
+    {
+        Console.WriteLine("Course created");
+        NavigationManager.NavigateTo("/");
+    }
+    
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherDashboard/TeacherAllCoursesTableRow.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherDashboard/TeacherAllCoursesTableRow.razor
@@ -6,7 +6,7 @@
         <td>@Course.Modules.Count</td>
         <td class="text-end">
             <a class="text-decoration-none" href="@($"/courses/{Course.Id}/overview")">Visa</a>
-            <a class="ms-2 text-decoration-none pe-2" href="#">Redigera</a>
+            <a class="ms-2 text-decoration-none pe-2" href="@($"/create-course/{Course.Id}")">Redigera</a>
         </td>
     </tr>
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Layout/NavMenu.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Layout/NavMenu.razor
@@ -71,7 +71,7 @@
     {
         new("bi bi-house", "Dashboard", "", NavLinkMatch.All),
         new("bi bi-book", "Kurser", "courses"),
-        new("bi bi-plus-circle", "Skapa ny kurs", "create-course"),
+        new("bi bi-plus-circle", "Skapa och redigera kurser", "create-course"),
         new("bi bi-people", "Användare", "Users"),
         new("bi bi-list-task", "Inlämningar", "demoauth")
     };

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Courses.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Courses.razor
@@ -105,14 +105,15 @@
 
                                 <button type="button"
                                         class="btn btn-link text-primary modules-icon-button"
-                                        title="Redigera modul">
+                                        title="Redigera kurs"
+                                        @onclick="() => UpdateCourse(course.Id)">
                                     <i class="bi bi-pencil-square" aria-hidden="true"></i>
                                     Redigera kurs
                                 </button>
 
                                 <button type="button"
                                         class="btn btn-link text-danger modules-icon-button"
-                                        title="Ta bort modul"
+                                        title="Ta bort kurs"
                                         @onclick="() => DeleteCourse(course)">
                                     <i class="bi bi-trash3" aria-hidden="true"></i>
                                     Radera kurs
@@ -422,6 +423,8 @@
 
     private void GoToCreateCourses() => NavigationManager.NavigateTo("/create-course");
     private void GoToCourseOverview(Guid courseId) => NavigationManager.NavigateTo($"/courses/{courseId}");
+
+    private void UpdateCourse(Guid courseId) => NavigationManager.NavigateTo($"/create-course/{courseId}");
 
     private async Task DeleteCourse(CourseDto course)
     {

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/CreateCourse.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/CreateCourse.razor
@@ -1,7 +1,9 @@
 ﻿@page "/create-course/{CourseId?}"
 @inject IApiService ApiService
+@inject NavigationManager NavigationManager
 
 @attribute [Authorize(Roles = RolesNames.Teacher)]
+
 @if (!_isEdit) {
     <PageTitle>Skapa Kurs</PageTitle>
 } else {
@@ -12,6 +14,16 @@
     <div class="container">
         <div class="alert alert-success alert-dismissible" role="alert">
             <div>@_successMessage</div>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    </div>
+}
+
+@if (_errorMessage is not null) {
+    <div class="container">
+        <div class="alert alert-danger alert-dismissible" role="alert">
+            <span>@_errorMessage</span>
+            <button type="button" class="btn btn-link" @onclick="() => NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true)">Ladda om</button>
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     </div>
@@ -32,15 +44,14 @@
     private List<string> _overlapErrors = [];
     private bool _isLoading = false;
     private string? _successMessage;
+    private string? _errorMessage;
 
     protected async override Task OnInitializedAsync()
     {
         if (CourseId is null) {
             InitCourse();
-            Console.WriteLine("is null");
         } else {
             await GetCourse();
-            Console.WriteLine("is not null");
         }
     }
 
@@ -94,6 +105,7 @@
     private async Task SubmitCourse()
     {
         _successMessage = null;
+        _errorMessage = null;
 
         if (_course.Modules.Count > 0) {
             CheckForOverlap();
@@ -109,14 +121,19 @@
                 await CreateNewCourse();
             }
             isSuccess = true;
-        } catch (Exception) {
+        } catch (Exception e) {
             isSuccess = false;
+            if (e.Message == "405 MethodNotAllowed") {
+                _errorMessage = "Ett fel har uppstått. Snälla ladda om sidan och försök igen.";
+            }
         } finally {
             _isLoading = false;
         }
         if (isSuccess) {
             _successMessage = _isEdit ? $"Kurs {_course.Name} redigerad" : $"Kurs {_course.Name} sparad";
             InitCourse();
+            CourseId = null;
+            NavigationManager.NavigateTo("/create-course");
         }
     }
 

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/CreateCourse.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/CreateCourse.razor
@@ -1,9 +1,12 @@
-﻿@page "/create-course"
+﻿@page "/create-course/{CourseId?}"
 @inject IApiService ApiService
 
 @attribute [Authorize(Roles = RolesNames.Teacher)]
-
-<PageTitle>Skapa Kurs</PageTitle>
+@if (!_isEdit) {
+    <PageTitle>Skapa Kurs</PageTitle>
+} else {
+    <PageTitle>Redigera Kurs</PageTitle>
+}
 
 @if (_successMessage is not null) {
     <div class="container">
@@ -15,6 +18,7 @@
 }
 
 <CreateCourseForm Course="_course"
+                  IsEditing="_isEdit"
                   OnAddModule="AddModule"
                   OnRemoveModule="RemoveModule"
                   OnCreateCourse="SubmitCourse"
@@ -22,20 +26,53 @@
                   OverlapErrors="_overlapErrors" />
 
 @code {
-    private CourseFormModel _course = null!;
+    [Parameter] public string? CourseId { get; set; }
+    private bool _isEdit = false;
+    private CourseFormModel _course = new();
     private List<string> _overlapErrors = [];
     private bool _isLoading = false;
     private string? _successMessage;
 
-    protected override void OnInitialized()
+    protected async override Task OnInitializedAsync()
     {
-        InitCourse();
+        if (CourseId is null) {
+            InitCourse();
+            Console.WriteLine("is null");
+        } else {
+            await GetCourse();
+            Console.WriteLine("is not null");
+        }
     }
 
     private void InitCourse()
     {
         _course = new() { Id = Guid.NewGuid() };
         AddModule();
+        _isEdit = false;
+    }
+
+    private async Task GetCourse()
+    {
+        if (!Guid.TryParse(CourseId, out _)) {
+            InitCourse();
+            return;
+        }
+
+        CourseDto? courseDto = await ApiService.GetAsync<CourseDto>($"api/courses/{CourseId}");
+        if (courseDto is null) {
+            InitCourse();
+            return;
+        }
+
+        _course = new() {
+            Id = courseDto.Id,
+            Name = courseDto.Name,
+            Description = courseDto.Description,
+            StartDate = courseDto.StartDate,
+            EndDate = courseDto.EndDate,
+            Modules = []
+        };
+        _isEdit = true;
     }
 
     private void AddModule()
@@ -61,16 +98,30 @@
         if (_course.Modules.Count > 0) {
             CheckForOverlap();
             if (_overlapErrors.Count > 0) return;
-            // if (_overlapErrors.Count > 0) {
-            //     Console.Write($"Errors occured: {Environment.NewLine}");
-            //     foreach (var error in _overlapErrors) {
-            //         Console.Write($"- {error}");
-            //         Console.WriteLine();
-            //         return;
-            //     }
-            // }
         }
 
+        bool isSuccess = false;
+        _isLoading = true;
+        try {
+            if (_isEdit) {
+                await UpdateCourse();
+            } else {
+                await CreateNewCourse();
+            }
+            isSuccess = true;
+        } catch (Exception) {
+            isSuccess = false;
+        } finally {
+            _isLoading = false;
+        }
+        if (isSuccess) {
+            _successMessage = _isEdit ? $"Kurs {_course.Name} redigerad" : $"Kurs {_course.Name} sparad";
+            InitCourse();
+        }
+    }
+
+    private async Task CreateNewCourse()
+    {
         CreateCourseDto createCourseDto = new() {
             Name = _course.Name,
             Description = _course.Description,
@@ -84,20 +135,18 @@
                 CourseId: (Guid)m.CourseId!
             )).ToList()
         };
+        await ApiService.PostAsync<CreateCourseDto, bool>("api/courses", createCourseDto);
+    }
 
-        bool isSuccess = false;
-        _isLoading = true;
-        try {
-            await ApiService.PostAsync<CreateCourseDto, bool>("api/courses", createCourseDto);
-            isSuccess = true;
-        } catch (Exception) {
-            isSuccess = false;
-        }
-        _isLoading = false;
-        if (isSuccess) {
-            _successMessage = $"Kurs {_course.Name} sparad";
-            InitCourse();
-        }
+    private async Task UpdateCourse()
+    {
+        UpdateCourseDto updateCourseDto = new(
+            Name: _course.Name,
+            Description: _course.Description,
+            StartDate: (DateOnly)_course.StartDate!,
+            EndDate: (DateOnly)_course.EndDate!
+        );
+        await ApiService.PatchAsync<UpdateCourseDto, bool>($"api/courses/{CourseId}", updateCourseDto);
     }
 
     private void CheckForOverlap()

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
@@ -299,7 +299,7 @@ else
 
     private void HandleEditCourse()
     {
-        // Navigate to edit page or open modal
+        NavigationManager.NavigateTo($"/create-course/{CourseId}");
     }
 
     private void HandleTabChanged(string tabValue)

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -44,14 +44,16 @@ public class CourseRepository : RepositoryBase<Course>, ICourseRepository
                         .ToPagedResultAsync(param, token);
     }
 
-    public async Task<Course?> GetCourseById(Guid id, bool trackChanges, CancellationToken token)
+    public async Task<Course?> GetCourseById(Guid id, bool trackChanges, CancellationToken token, bool includeAllData = true)
     {
-        return await FindAll(trackChanges: trackChanges)
-                        .Include(c => c.Modules)
+        var query = FindAll(trackChanges: trackChanges);
+        if (includeAllData) {
+            query = query.Include(c => c.Modules)
                             .ThenInclude(m => m.Activities)
                                 .ThenInclude(a => a.Type)
-                        .Include(c => c.Students)
-                        .FirstOrDefaultAsync(c => c.Id == id, token);
+                          .Include(c => c.Students);
+        }
+        return await query.FirstOrDefaultAsync(c => c.Id == id, token);
     }
 
     public async Task<Course?> GetCourseFromUserId(Guid userId, bool trackChanges, CancellationToken token)

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -87,7 +87,7 @@ public class CourseService : ICourseService
 
     public async Task UpdateCourse(Guid id, UpdateCourseDto updateCourseDto, CancellationToken token)
     {
-        Course? course = await _uow.Courses.GetCourseById(id, trackChanges: false, token)
+        Course? course = await _uow.Courses.GetCourseById(id, trackChanges: false, token, includeAllData: false)
            ?? throw new CourseNotFoundException(id);
 
         if (updateCourseDto.Name is not null)


### PR DESCRIPTION
Ifall man sätter ett ID i /create-course/{Id} så går formuläret i edit mode, så alla fält fylls i, text ändras, och man kan inte redigera moduler (var för struligt för nu, t.ex. måste en module upsert skapas). 
<img width="1415" height="846" alt="bild" src="https://github.com/user-attachments/assets/2c3e9968-7472-4c4a-834f-7deef439b04b" />

Finns en "bug" att om du clickar på create-course nav-knappen medan du är på sidan så laddas sidan inte om men ID: kommer bli null. Detta gör att servern kommer svara med 405 MethodNotAllowed (PATCH /api/courses finns ej). Hittade ingen snygg lösning för detta så i detta fall kommer en ruta upp där användaren kan ladda om sidan manuellt.