### PR TITLE
Added endpoint for updating user information

### DIFF
--- a/LMS.Presentation/Controllers/UsersController.cs
+++ b/LMS.Presentation/Controllers/UsersController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Service.Contracts;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace LMS.Presentation.Controllers;
 
@@ -49,5 +50,17 @@ public class UsersController(IServiceManager serviceManager) : ControllerBase
     {
         await UserService.DeleteUser(id);
         return NoContent();
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(string id, [FromBody] UpdateUserDto request, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var updatedUser = await UserService.UpdateUser(id, request, token);
+        return Ok(updatedUser);
     }
 }

--- a/LMS.Services/UserService.cs
+++ b/LMS.Services/UserService.cs
@@ -7,6 +7,7 @@ using LMS.Shared.DTOs.UserDtos;
 using LMS.Shared.Pagination;
 using Microsoft.AspNetCore.Identity;
 using Service.Contracts;
+using System.ComponentModel.DataAnnotations;
 
 namespace LMS.Services;
 
@@ -98,6 +99,9 @@ public class UserService : IUserService
     }
 
     private static UserDto MapToUserDto(ApplicationUser user)
+        => MapToUserDto(user, null);
+
+    private static UserDto MapToUserDto(ApplicationUser user, string? role)
     {
         return new UserDto
         {
@@ -105,7 +109,50 @@ public class UserService : IUserService
             Email = user.Email ?? string.Empty,
             FirstName = user.FirstName,
             LastName = user.LastName,
+            Role = role,
             CourseId = user.Course?.Id,
         };
     }
+
+    public async Task<UserDto> UpdateUser(string id, UpdateUserDto request, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var user = await _uow.Users.GetByIdWithCourseAsync(id, token);
+        if (user is null)
+            throw new NotFoundException("Användaren hittades inte");
+
+        ValidateUpdateRequest(request);
+
+        var normalizedEmail = request.Email.Trim();
+        var duplicateUser = await _userManager.FindByEmailAsync(normalizedEmail);
+        if (duplicateUser is not null && duplicateUser.Id != user.Id)
+            throw new BadRequestException("E-postadressen är redan registrerad");
+
+        user.Email = normalizedEmail;
+        user.UserName = normalizedEmail;
+        user.FirstName = request.FirstName.Trim();
+        user.LastName = request.LastName.Trim();
+
+        var updateResult = await _userManager.UpdateAsync(user);
+        if (!updateResult.Succeeded)
+            throw new BadRequestException(GetIdentityErrors(updateResult));
+
+        return MapToUserDto(user);
+    }
+
+    private static void ValidateUpdateRequest(UpdateUserDto request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Email))
+            throw new BadRequestException("Email krävs");
+
+        if (string.IsNullOrWhiteSpace(request.FirstName))
+            throw new BadRequestException("Förnamn krävs");
+
+        if (string.IsNullOrWhiteSpace(request.LastName))
+            throw new BadRequestException("Efternamn krävs");
+    }
+
+    private static string GetIdentityErrors(IdentityResult result)
+        => string.Join(", ", result.Errors.Select(e => e.Description));
 }

--- a/LMS.Services/UserService.cs
+++ b/LMS.Services/UserService.cs
@@ -118,7 +118,7 @@ public class UserService : IUserService
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var user = await _uow.Users.GetByIdWithCourseAsync(id, token);
+        var user = await _userManager.FindByIdAsync(id);
         if (user is null)
             throw new NotFoundException("Användaren hittades inte");
 
@@ -138,7 +138,10 @@ public class UserService : IUserService
         if (!updateResult.Succeeded)
             throw new BadRequestException(GetIdentityErrors(updateResult));
 
-        return MapToUserDto(user);
+        var updatedUser = await _uow.Users.GetByIdWithCourseAsync(user.Id, token)
+            ?? throw new NotFoundException("Användaren hittades inte");
+
+        return MapToUserDto(updatedUser);
     }
 
     private static void ValidateUpdateRequest(UpdateUserDto request)

--- a/LMS.Shared/DTOs/AuthDtos/UpdateUserDto.cs
+++ b/LMS.Shared/DTOs/AuthDtos/UpdateUserDto.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LMS.Shared.DTOs.AuthDtos;
+
+public record UpdateUserDto
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; init; } = string.Empty;
+
+    [Required]
+    public string FirstName { get; init; } = string.Empty;
+
+    [Required]
+    public string LastName { get; init; } = string.Empty;
+}

--- a/LMS.Test/Controllers/UsersControllerTest.cs
+++ b/LMS.Test/Controllers/UsersControllerTest.cs
@@ -110,6 +110,43 @@ public class UsersControllerTest
         userServiceMock.Verify(s => s.CreateUser(userRegistrationDto), Times.Once);
     }
 
+    [Fact]
+    [Trait("Layer", "Controller")]
+    public async Task Update_WhenUserIsValid_ReturnsOkWithUpdatedUser()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var ct = new CancellationTokenSource().Token;
+        var updateUserDto = new UpdateUserDto
+        {
+            Email = "updated@example.com",
+            FirstName = "Updated",
+            LastName = "User"
+        };
+        var updatedUser = new UserDto
+        {
+            Id = userId,
+            Email = updateUserDto.Email,
+            FirstName = updateUserDto.FirstName,
+            LastName = updateUserDto.LastName
+        };
+
+        var userServiceMock = new Mock<IUserService>();
+        userServiceMock
+            .Setup(s => s.UpdateUser(userId, updateUserDto, ct))
+            .ReturnsAsync(updatedUser);
+
+        var controller = CreateController(userServiceMock);
+
+        // Act
+        var result = await controller.Update(userId, updateUserDto, ct);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(updatedUser, okResult.Value);
+        userServiceMock.Verify(s => s.UpdateUser(userId, updateUserDto, ct), Times.Once);
+    }
+
     private static UsersController CreateController(Mock<IUserService> userServiceMock)
     {
         var serviceManagerMock = new Mock<IServiceManager>();

--- a/Service.Contracts/IUserService.cs
+++ b/Service.Contracts/IUserService.cs
@@ -9,4 +9,5 @@ public interface IUserService
     Task<UserDto> GetUserById(string id);
     Task<UserDto> CreateUser(UserRegistrationDto request);
     Task DeleteUser(string id);
+    Task<UserDto> UpdateUser(string id, UpdateUserDto request, CancellationToken token);
 }


### PR DESCRIPTION
In this PR I added an `UpdateUserDto` for updating `Email`, `FirstName`, and `LastName`, added a `PUT` endpoint for updating a user by id, and implementing the update logic in `UserService`.

**The service now:**
-validates required fields
-checks that the user exists
-prevents duplicate email addresses
-updates the user through UserManager

Also includes a controller test verifying that a valid update request returns 200 OK with the updated user.