### PR TITLE
Validate activity scheduling within modules

### DIFF
--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ActivityFormModel.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ActivityFormModel.cs
@@ -10,6 +10,8 @@ public sealed class ActivityFormModel
     public Guid ModuleId { get; set; }
 
     public string ModuleName { get; set; } = string.Empty;
+    public string ModuleStartDateTimeMin { get; set; } = string.Empty;
+    public string ModuleEndDateTimeMax { get; set; } = string.Empty;
 
     [Required(ErrorMessage = "Aktivitetsnamn är obligatoriskt.")]
     [StringLength(120, ErrorMessage = "Aktivitetsnamnet får vara högst 120 tecken.")]

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/AddActivityModal.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/AddActivityModal.razor
@@ -60,6 +60,8 @@
                         <InputText id="activity-start"
                                    class="form-control"
                                    type="datetime-local"
+                                   min="@Model.ModuleStartDateTimeMin"
+                                   max="@Model.ModuleEndDateTimeMax"
                                    @bind-Value="Model.StartDateTimeLocal"
                                    disabled="@IsSubmitting" />
                         <ValidationMessage For="() => Model.StartDateTimeLocal" />
@@ -70,6 +72,8 @@
                         <InputText id="activity-end"
                                    class="form-control"
                                    type="datetime-local"
+                                   min="@Model.ModuleStartDateTimeMin"
+                                   max="@Model.ModuleEndDateTimeMax"
                                    @bind-Value="Model.EndDateTimeLocal"
                                    disabled="@IsSubmitting" />
                         <ValidationMessage For="() => Model.EndDateTimeLocal" />

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
@@ -379,15 +379,32 @@ else
             return;
         }
 
+        var (moduleStartMin, moduleEndMax) = GetModuleDateTimeBounds(module);
         var start = DateTime.Now;
+
+        if (start < moduleStartMin)
+        {
+            start = moduleStartMin;
+        }
+        else if (start > moduleEndMax)
+        {
+            start = moduleEndMax;
+        }
+
         var end = start.AddHours(2);
+        if (end > moduleEndMax)
+        {
+            end = moduleEndMax;
+        }
 
         activityForm = new ActivityFormModel
         {
             ModuleId = moduleId,
             ModuleName = module.Title,
-            StartDateTimeLocal = start.ToString("yyyy-MM-ddTHH:mm"),
-            EndDateTimeLocal = end.ToString("yyyy-MM-ddTHH:mm")
+            ModuleStartDateTimeMin = FormatDateTimeLocal(moduleStartMin),
+            ModuleEndDateTimeMax = FormatDateTimeLocal(moduleEndMax),
+            StartDateTimeLocal = FormatDateTimeLocal(start),
+            EndDateTimeLocal = FormatDateTimeLocal(end)
         };
 
         isActivityModalOpen = true;
@@ -405,9 +422,11 @@ else
             return;
         }
 
-        var moduleName = _courseModules
-            .FirstOrDefault(m => m.Id == activity.ModuleId)?.Title
-            ?? "Modul";
+        var module = _courseModules.FirstOrDefault(m => m.Id == activity.ModuleId);
+        var moduleName = module?.Title ?? "Modul";
+        var (moduleStartMin, moduleEndMax) = module is null
+            ? (activity.Date, activity.Deadline ?? activity.Date.AddHours(2))
+            : GetModuleDateTimeBounds(module);
 
         var endDate = activity.Deadline ?? activity.Date.AddHours(2);
 
@@ -416,10 +435,12 @@ else
             ActivityId = activityId,
             ModuleId = moduleId,
             ModuleName = moduleName,
+            ModuleStartDateTimeMin = FormatDateTimeLocal(moduleStartMin),
+            ModuleEndDateTimeMax = FormatDateTimeLocal(moduleEndMax),
             Name = activity.Title,
             Description = activity.Description,
-            StartDateTimeLocal = activity.Date.ToString("yyyy-MM-ddTHH:mm"),
-            EndDateTimeLocal = endDate.ToString("yyyy-MM-ddTHH:mm"),
+            StartDateTimeLocal = FormatDateTimeLocal(activity.Date),
+            EndDateTimeLocal = FormatDateTimeLocal(endDate),
             TypeName = activity.Type.ToString()
         };
 
@@ -652,5 +673,15 @@ else
         }
 
         return null;
+    }
+
+    private static (DateTime Min, DateTime Max) GetModuleDateTimeBounds(ModuleModel module)
+    {
+        return (module.StartDate.Date, module.EndDate.Date.AddDays(1).AddMinutes(-1));
+    }
+
+    private static string FormatDateTimeLocal(DateTime value)
+    {
+        return value.ToString("yyyy-MM-ddTHH:mm");
     }
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
@@ -664,12 +664,12 @@ else
 
         var hasOverlap = module.Activities.Any(activity =>
             activity.Id != currentActivityId &&
-            startDate < (activity.Deadline ?? activity.Date) &&
-            endDate > activity.Date);
+            startDate <= (activity.Deadline ?? activity.Date) &&
+            endDate >= activity.Date);
 
         if (hasOverlap)
         {
-            return "Aktivitetens datum överlappar med en annan aktivitet i den här modulen.";
+            return "Aktivitetens datum överlappar med en annan aktivitet i den här modulen. En aktivitet kan inte sluta samtidigt som en annan börjar.";
         }
 
         return null;

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
@@ -566,6 +566,23 @@ else
             return;
         }
 
+        var selectedModule = _courseModules.FirstOrDefault(module =>
+            Guid.TryParse(module.Id, out var moduleId) &&
+            moduleId == activityForm.ModuleId);
+
+        if (selectedModule is null)
+        {
+            activitySubmitError = "Kunde inte hitta den valda modulen.";
+            return;
+        }
+
+        var validationError = ValidateActivitySchedule(selectedModule, startDate, endDate);
+        if (validationError is not null)
+        {
+            activitySubmitError = validationError;
+            return;
+        }
+
         isActivitySubmitting = true;
 
         try
@@ -611,5 +628,29 @@ else
         {
             isActivitySubmitting = false;
         }
+    }
+
+    private string? ValidateActivitySchedule(ModuleModel module, DateTime startDate, DateTime endDate)
+    {
+        if (startDate.Date < module.StartDate.Date || endDate.Date > module.EndDate.Date)
+        {
+            return $"Aktivitetens datum måste ligga inom modulens datum ({module.StartDate:yyyy-MM-dd} - {module.EndDate:yyyy-MM-dd}).";
+        }
+
+        var currentActivityId = activityForm.IsEditMode && activityForm.ActivityId.HasValue
+            ? activityForm.ActivityId.Value.ToString()
+            : null;
+
+        var hasOverlap = module.Activities.Any(activity =>
+            activity.Id != currentActivityId &&
+            startDate < (activity.Deadline ?? activity.Date) &&
+            endDate > activity.Date);
+
+        if (hasOverlap)
+        {
+            return "Aktivitetens datum överlappar med en annan aktivitet i den här modulen.";
+        }
+
+        return null;
     }
 }

--- a/LMS.Services/ActivityService.cs
+++ b/LMS.Services/ActivityService.cs
@@ -50,7 +50,11 @@ public class ActivityService : IActivityService
             ?? throw new ModuleNotFoundException(request.ModuleId);
         var activityType = _uow.ActivityTypes.FirstOrDefault(a => a.Name == request.Type.Name)
             ?? throw new ActivityTypeNotFoundException(request.Type.Name);
-        // TODO: check start/end is within module and not overlapping with other activities in the same module
+
+        ValidateDateRange(request.StartDate, request.EndDate);
+        ValidateActivityWithinModule(request.StartDate, request.EndDate, module);
+        await EnsureActivityDoesNotOverlapAsync(request.ModuleId, request.StartDate, request.EndDate);
+
         var activity = new Activity
         {
             Name = request.Name,
@@ -76,6 +80,10 @@ public class ActivityService : IActivityService
         var activityType = _uow.ActivityTypes.FirstOrDefault(a => a.Name == request.Type.Name)
             ?? throw new ActivityTypeNotFoundException(request.Type.Name);
 
+        ValidateDateRange(request.StartDate, request.EndDate);
+        ValidateActivityWithinModule(request.StartDate, request.EndDate, activity.Module);
+        await EnsureActivityDoesNotOverlapAsync(activity.ModuleId, request.StartDate, request.EndDate, activity.Id);
+
         activity.Name = request.Name;
         activity.Description = request.Description;
         activity.StartDate = request.StartDate;
@@ -100,6 +108,43 @@ public class ActivityService : IActivityService
             await _uow.CompleteAsync(CancellationToken.None);
         } catch (Exception ex) {
             throw new BadRequestException(ex.Message);
+        }
+    }
+
+    private static void ValidateDateRange(DateTime startDate, DateTime endDate)
+    {
+        if (startDate > endDate)
+        {
+            throw new BadRequestException("Aktivitetens startdatum kan inte vara senare än slutdatum.");
+        }
+    }
+
+    private static void ValidateActivityWithinModule(DateTime startDate, DateTime endDate, Module module)
+    {
+        if (DateOnly.FromDateTime(startDate) < module.StartDate ||
+            DateOnly.FromDateTime(endDate) > module.EndDate)
+        {
+            throw new BadRequestException(
+                $"Aktivitetens datum måste ligga inom modulens datum ({module.StartDate:yyyy-MM-dd} - {module.EndDate:yyyy-MM-dd}).");
+        }
+    }
+
+    private async Task EnsureActivityDoesNotOverlapAsync(
+        Guid moduleId,
+        DateTime startDate,
+        DateTime endDate,
+        Guid? currentActivityId = null)
+    {
+        var existingActivities = await _uow.Activities.GetActivitiesFromModuleId(moduleId);
+
+        var hasOverlap = existingActivities.Any(activity =>
+            activity.Id != currentActivityId &&
+            startDate < activity.EndDate &&
+            endDate > activity.StartDate);
+
+        if (hasOverlap)
+        {
+            throw new BadRequestException("Aktivitetens datum överlappar med en annan aktivitet i den här modulen.");
         }
     }
 }

--- a/LMS.Services/ActivityService.cs
+++ b/LMS.Services/ActivityService.cs
@@ -64,11 +64,14 @@ public class ActivityService : IActivityService
             Type = activityType,
             Module = module,
         };
-        try {
+        try
+        {
             _uow.Activities.Create(activity);
             await _uow.CompleteAsync(CancellationToken.None);
             return _mapper.Map<ActivityDto>(activity);
-        } catch (Exception ex) {
+        }
+        catch (Exception ex)
+        {
             throw new BadRequestException(ex.Message);
         }
     }
@@ -90,10 +93,13 @@ public class ActivityService : IActivityService
         activity.EndDate = request.EndDate;
         activity.Type = activityType;
 
-        try {
+        try
+        {
             _uow.Activities.Update(activity);
             await _uow.CompleteAsync(CancellationToken.None);
-        } catch (Exception ex) {
+        }
+        catch (Exception ex)
+        {
             throw new BadRequestException(ex.Message);
         }
     }
@@ -103,10 +109,13 @@ public class ActivityService : IActivityService
         var activity = await _uow.Activities.GetActivityById(id, trackChanges: true)
             ?? throw new ActivityNotFoundException(id);
 
-        try {
+        try
+        {
             _uow.Activities.Delete(activity);
             await _uow.CompleteAsync(CancellationToken.None);
-        } catch (Exception ex) {
+        }
+        catch (Exception ex)
+        {
             throw new BadRequestException(ex.Message);
         }
     }
@@ -139,12 +148,12 @@ public class ActivityService : IActivityService
 
         var hasOverlap = existingActivities.Any(activity =>
             activity.Id != currentActivityId &&
-            startDate < activity.EndDate &&
-            endDate > activity.StartDate);
+            startDate <= activity.EndDate &&
+            endDate >= activity.StartDate);
 
         if (hasOverlap)
         {
-            throw new BadRequestException("Aktivitetens datum överlappar med en annan aktivitet i den här modulen.");
+            throw new BadRequestException("Aktivitetens datum överlappar med en annan aktivitet i den här modulen. En aktivitet kan inte sluta samtidigt som en annan börjar.");
         }
     }
 }


### PR DESCRIPTION
**Changes:**
Adds activity scheduling validation so activities must stay within their module dates and cannot overlap other activities in the same module. This is implemented in `ActivityService` and mirrored in the teacher overview UI for faster feedback.

-Activities can still be back-to-back; only actual overlaps are blocked.
-No DTO changes were made for activities.