### PR TITLE
Display activity date and time consistently for both teacher and student view

### DIFF
--- a/LMS.Blazor/LMS.Blazor.Client/Components/CourseOverview/ActivityItem.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/CourseOverview/ActivityItem.razor
@@ -6,10 +6,26 @@
             <span class="fw-semibold ms-1">@Activity.Title</span>
             <span class="badge rounded-pill bg-primary bg-opacity-75">@Activity.Type</span>
 
-            <p class="text-muted mb-0">
-                <i class="bi bi-calendar"></i>
-                @Activity.Date
-             </p>
+            <div class="text-secondary mb-3">
+                <i class="bi bi-calendar3 me-1"></i>
+                @Activity.StartDate.ToString("yyyy-MM-dd 'kl.' HH:mm")
+
+                @if (Activity.EndDate is not null)
+                {
+                    @if (Activity.Type == "Inlämning")
+                    {
+                        <span class="ms-3 text-warning-emphasis">
+                            <i class="bi bi-clock me-1"></i>
+                            <span>Deadline: @Activity.EndDate.Value.ToString("yyyy-MM-dd 'kl.' HH:mm")</span>
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="mx-2">-</span>
+                        <span>@Activity.EndDate.Value.ToString("yyyy-MM-dd 'kl.' HH:mm")</span>
+                    }
+                }
+            </div>
         </div>
         <div class="text-end">
             @if (Activity.HasDocument)

--- a/LMS.Blazor/LMS.Blazor.Client/Components/CourseOverview/CourseOverviewModels.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/CourseOverview/CourseOverviewModels.cs
@@ -26,7 +26,8 @@ public sealed class ActivityViewModel
     public string Id { get; init; } = Guid.NewGuid().ToString();
     public string Type { get; init; } = string.Empty;
     public string Title { get; init; } = string.Empty;
-    public string Date { get; init; } = string.Empty;
+    public DateTime StartDate { get; init; }
+    public DateTime? EndDate { get; init; }
     public bool HasDocument { get; init; }
     public string StatusText { get; init; } = string.Empty;
     public string? StatusIcon { get; init; }

--- a/LMS.Blazor/LMS.Blazor.Client/Components/CourseOverview/ModuleItem.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/CourseOverview/ModuleItem.razor
@@ -98,7 +98,8 @@
             Id = s.Id.ToString(),
             Title = s.Name,
             Type = s.Type.Name,
-            Date = $"{s.StartDate} - {s.EndDate}",
+            StartDate = s.StartDate,
+            EndDate = s.EndDate
         }).ToList();
     }
 

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleActivityItem.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/ModulesComponents/ModuleActivityItem.razor
@@ -8,14 +8,22 @@
 
             <div class="text-secondary mb-3">
                 <i class="bi bi-calendar3 me-1"></i>
-                @Activity.Date.ToString("yyyy-MM-dd")
+                @Activity.Date.ToString("yyyy-MM-dd 'kl.' HH:mm")
 
                 @if (Activity.Deadline is not null)
                 {
-                    <span class="ms-2 text-warning-emphasis">
-                        <i class="bi bi-clock me-1"></i>
-                        Deadline: @Activity.Deadline.Value.ToString("yyyy-MM-dd")
-                    </span>
+                    @if (Activity.Type == "Inlämning")
+                    {
+                        <span class="ms-3 text-warning-emphasis">
+                            <i class="bi bi-clock me-1"></i>
+                            <span>Deadline: @Activity.Deadline.Value.ToString("yyyy-MM-dd 'kl.' HH:mm")</span>
+                        </span>
+                    }
+                    else
+                    {
+                        <span class="mx-2">-</span>
+                        <span>@Activity.Deadline.Value.ToString("yyyy-MM-dd 'kl.' HH:mm")</span>
+                    }
                 }
             </div>
         </div>

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/MyCourse.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/MyCourse.razor
@@ -45,7 +45,8 @@
                 {
                     Title = a.Name,
                     Type = a.Type.Name,
-                    Date = $"{a.StartDate} - {a.EndDate}",
+                    StartDate = a.StartDate,
+                    EndDate = a.EndDate
                 }).ToArray(),
             }).ToArray(),
         };


### PR DESCRIPTION
I fixed so activity date and time are displayed consistently in both `MyCourse` for student and in `CourseDetails` for teacher. 

**Changes:**
-Display both date and time  
-Display time in swedish format
-Display `Deadline` if activity is of type "Inlämning".

<img width="2186" height="940" alt="image" src="https://github.com/user-attachments/assets/7c1eae73-945b-4010-9ba9-37585943509a" />
