### PR TITLE
Default sort order in repositories

### DIFF
--- a/LMS.Infractructure/Repositories/ActivityRepository.cs
+++ b/LMS.Infractructure/Repositories/ActivityRepository.cs
@@ -16,6 +16,7 @@ public class ActivityRepository(ApplicationDbContext context)
             .Where(s => s.Module.Id == moduleId)
             .Include(s => s.Module)
             .Include(s => s.Type)
+            .OrderBy(s => s.StartDate)
             .ToListAsync();
     }
 
@@ -32,6 +33,7 @@ public class ActivityRepository(ApplicationDbContext context)
         return await FindAll()
             .Include(s => s.Module)
             .Include(s => s.Type)
+            .OrderBy(s => s.StartDate)
             .ToPagedResultAsync(query);
     }
 }

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -10,15 +10,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace LMS.Infractructure.Repositories;
 
-public class CourseRepository : RepositoryBase<Course>, ICourseRepository
+public class CourseRepository(ApplicationDbContext context)
+    : RepositoryBase<Course>(context), ICourseRepository
 {
-    private readonly ApplicationDbContext _context;
-
-    public CourseRepository(ApplicationDbContext context) : base(context)
-    {
-        _context = context;
-    }
-
     public async Task<PagedResult<Course>> GetAllCourses(AllCoursesParams param, CancellationToken token)
     {
         var query = FindAll(trackChanges: false);
@@ -41,6 +35,7 @@ public class CourseRepository : RepositoryBase<Course>, ICourseRepository
                             .ThenInclude(m => m.Activities)
                                 .ThenInclude(a => a.Type)
                         .Include(c => c.Students)
+                        .OrderBy(c => c.StartDate)
                         .ToPagedResultAsync(param, token);
     }
 

--- a/LMS.Infractructure/Repositories/ModuleRepository.cs
+++ b/LMS.Infractructure/Repositories/ModuleRepository.cs
@@ -7,43 +7,36 @@ using Microsoft.EntityFrameworkCore;
 
 namespace LMS.Infractructure.Repositories;
 
-public class ModuleRepository : RepositoryBase<Module>, IModuleRepository
+public class ModuleRepository(ApplicationDbContext context)
+    : RepositoryBase<Module>(context), IModuleRepository
 {
-    private readonly ApplicationDbContext _context;
-
-    public ModuleRepository(ApplicationDbContext context) : base(context)
-    {
-        _context = context;
-    }
-
     public async Task<PagedResult<Module>> GetAllModulesAsync(PagedQuery query)
     {
-        return await _context.Modules
-            .AsNoTracking()
+        return await FindAll()
             .Include(m => m.Course)
+            .OrderBy(m => m.StartDate)
             .ToPagedResultAsync(query);
     }
 
     public async Task<Module?> GetModuleByIdAsync(Guid id)
     {
-        return await _context.Modules
-            .AsNoTracking()
+        return await FindAll()
             .Include(m => m.Course)
             .FirstOrDefaultAsync(m => m.Id == id);
     }
 
     public async Task<IReadOnlyCollection<Module>> GetModulesByCourseIdAsync(Guid courseId)
     {
-        return await _context.Modules
-            .AsNoTracking()
+        return await FindAll()
             .Include(m => m.Course)
             .Where(m => m.Course.Id == courseId)
+            .OrderBy(m => m.StartDate)
             .ToListAsync();
     }
 
     public async Task<Module?> GetModuleByIdTrackedAsync(Guid id)
     {
-        return await _context.Modules
+        return await FindAll(trackChanges: true)
             .Include(m => m.Course)
             .FirstOrDefaultAsync(m => m.Id == id);
     }

--- a/LMS.Infractructure/Repositories/UserRepository.cs
+++ b/LMS.Infractructure/Repositories/UserRepository.cs
@@ -14,6 +14,7 @@ public class UserRepository(ApplicationDbContext context)
     {
         return await FindAll()
             .Include(u => u.Course)
+            .OrderBy(u => u.LastName).ThenBy(u => u.FirstName)
             .ToPagedResultAsync(query, ct);
     }
 


### PR DESCRIPTION
Set default sorted order

Courses, modules and activities are sorted by start date
Users are sorted by last name then by first name

Also made repositories use base functions instead of context