### PR TITLE
Handle 401 and 403

### DIFF
--- a/Domain.Models/Exceptions/UserForbiddenException.cs
+++ b/Domain.Models/Exceptions/UserForbiddenException.cs
@@ -1,0 +1,6 @@
+﻿using System.Net;
+
+namespace Domain.Models.Exceptions;
+
+public class UserForbiddenException(string message ="You're not allowed to access this resource", int code = 403) 
+    : TokenValidationException(message, code);

--- a/Domain.Models/Exceptions/UserForbiddenException.cs
+++ b/Domain.Models/Exceptions/UserForbiddenException.cs
@@ -1,6 +1,8 @@
-﻿using System.Net;
-
-namespace Domain.Models.Exceptions;
+﻿namespace Domain.Models.Exceptions;
 
 public class UserForbiddenException(string message ="You're not allowed to access this resource", int code = 403) 
-    : TokenValidationException(message, code);
+    : TokenValidationException(message, code)
+{
+    public UserForbiddenException() 
+        : this("You're not allowed to access this resource", 403) { }
+}

--- a/LMS.API/Extensions/ServiceExtensions.cs
+++ b/LMS.API/Extensions/ServiceExtensions.cs
@@ -79,7 +79,6 @@ public static class ServiceExtensions
                     options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
                 })
                 .AddApplicationPart(typeof(AssemblyReference).Assembly);
-        services.AddScoped<ControllerHelpers>();
     }
 
     public static void ConfigureSql(this IServiceCollection services, IConfiguration configuration)

--- a/LMS.API/Extensions/ServiceExtensions.cs
+++ b/LMS.API/Extensions/ServiceExtensions.cs
@@ -79,6 +79,7 @@ public static class ServiceExtensions
                     options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
                 })
                 .AddApplicationPart(typeof(AssemblyReference).Assembly);
+        services.AddScoped<ControllerHelpers>();
     }
 
     public static void ConfigureSql(this IServiceCollection services, IConfiguration configuration)

--- a/LMS.Blazor/LMS.Blazor.Client/Services/ClientApiService.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Services/ClientApiService.cs
@@ -74,9 +74,8 @@ public class ClientApiService : IApiService
 
     private async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken token)
     {
-        if (response.StatusCode == HttpStatusCode.Unauthorized ||
-            response.StatusCode == HttpStatusCode.Forbidden) {
-            //_navigationManager.NavigateTo("/Account/Login", forceLoad: true);
+        if (response.StatusCode == HttpStatusCode.Unauthorized) {
+            _navigationManager.NavigateTo("/Account/Login", forceLoad: true);
         }
 
         if (response.IsSuccessStatusCode)

--- a/LMS.Presentation/ControllerHelpers.cs
+++ b/LMS.Presentation/ControllerHelpers.cs
@@ -5,8 +5,8 @@ namespace LMS.Presentation;
 
 public class ControllerHelpers
 {
-    public bool IsStudent(ClaimsPrincipal user)
+    public static bool IsStudent(ClaimsPrincipal user)
         => user.IsInRole(RolesNames.Student);
-    public string? GetCurrentUserId(ClaimsPrincipal user)
+    public static string? GetCurrentUserId(ClaimsPrincipal user)
         => user.FindFirstValue(ClaimTypes.NameIdentifier);
 }

--- a/LMS.Presentation/ControllerHelpers.cs
+++ b/LMS.Presentation/ControllerHelpers.cs
@@ -1,0 +1,12 @@
+﻿using LMS.Shared.Constants;
+using System.Security.Claims;
+
+namespace LMS.Presentation;
+
+public class ControllerHelpers
+{
+    public bool IsStudent(ClaimsPrincipal user)
+        => user.IsInRole(RolesNames.Student);
+    public string? GetCurrentUserId(ClaimsPrincipal user)
+        => user.FindFirstValue(ClaimTypes.NameIdentifier);
+}

--- a/LMS.Presentation/Controllers/CoursesController.cs
+++ b/LMS.Presentation/Controllers/CoursesController.cs
@@ -17,11 +17,13 @@ public class CoursesController : ControllerBase
 {
     private readonly IServiceManager _serviceManager;
     private readonly ILogger<CoursesController> _logger;
+    private readonly ControllerHelpers _controllerHelpers;
 
-    public CoursesController(IServiceManager serviceManager, ILogger<CoursesController> logger)
+    public CoursesController(IServiceManager serviceManager, ILogger<CoursesController> logger, ControllerHelpers controllerHelpers)
     {
         _serviceManager = serviceManager;
         _logger = logger;
+        _controllerHelpers = controllerHelpers;
     }
 
     [HttpGet]
@@ -31,7 +33,7 @@ public class CoursesController : ControllerBase
         Description = "Gets all the courses that's in the database"
     )]
     [SwaggerResponse(StatusCodes.Status200OK)]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized, "You need to be a teacher")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "You need to be a teacher")]
     public async Task<IActionResult> GetAll([FromQuery] AllCoursesParams param, CancellationToken token)
     {
         var courseDtos = await _serviceManager.CourseService.GetAllCourses(param, token);
@@ -44,14 +46,14 @@ public class CoursesController : ControllerBase
         Description = "Get's a course by its ID. If a student is requesting a course they're not in, returns a 401"
     )]
     [SwaggerResponse(StatusCodes.Status200OK)]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized, "You need to be a teacher to request a course you're not in")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "You need to be a teacher to request a course you're not in")]
     [SwaggerResponse(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetById(Guid id, CancellationToken token)
     {
-        // If a student is requesting a course they're not in, return 401
+        // If a student is requesting a course they're not in, return 403
         string? currentStudentId = null;
-        if (IsStudent()) 
-            currentStudentId = GetCurrentUserId();
+        if (_controllerHelpers.IsStudent(User)) 
+            currentStudentId = _controllerHelpers.GetCurrentUserId(User);
 
         var courseDto = await _serviceManager.CourseService.GetCourseById(id, currentStudentId, token);
         return Ok(courseDto);
@@ -61,23 +63,18 @@ public class CoursesController : ControllerBase
     [SwaggerOperation(
         Summary = "Get a course by a user's ID",
         Description = "Takes a user's ID and returns the course they're in. " +
-            "Returns 401 if a student is trying to request someone else's course (ID of authorized user != ID in request)"
+            "Returns 403 if a student is trying to request someone else's course (ID of authorized user != ID in request)"
     )]
     [SwaggerResponse(StatusCodes.Status200OK)]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized, "You can only request your own course")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "You can only request your own course")]
     [SwaggerResponse(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetByUserId(Guid id, CancellationToken token)
+    public async Task<ActionResult<IReadOnlyCollection<CourseDto>>> GetByUserId(Guid id, CancellationToken token)
     {
-        // If a student is requesting someone else's courses, return 401
-        if (IsStudentGettingUnauthorizedCourse(id)) 
-        {
-            return Unauthorized(new ProblemDetails {
-                Title = "Unauthorized",
-                Detail = "You're not authorized to get this course"
-            });
-        }
+        string? currentStudentId = null;
+        if (_controllerHelpers.IsStudent(User))
+            currentStudentId = _controllerHelpers.GetCurrentUserId(User);
 
-        var courseDto = await _serviceManager.CourseService.GetCourseByUserId(id, token);        
+        var courseDto = await _serviceManager.CourseService.GetCourseByUserId(id, currentStudentId, token);
         return Ok(courseDto);
     }
 
@@ -130,15 +127,16 @@ public class CoursesController : ControllerBase
     )]
     [SwaggerResponse(StatusCodes.Status200OK)]
     [SwaggerResponse(StatusCodes.Status401Unauthorized)]
+    [SwaggerResponse(StatusCodes.Status403Forbidden)]
     [SwaggerResponse(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetMyCourseParticipants(CancellationToken token)
     {
-        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var userIdClaim = _controllerHelpers.GetCurrentUserId(User);
 
         if (!Guid.TryParse(userIdClaim, out var userId)) {
             return Unauthorized(new ProblemDetails {
                 Title = "Unauthorized",
-                Detail = "You're not allowed get the participants for this course"
+                Detail = "You need to login again"
             });
         }
 
@@ -150,27 +148,14 @@ public class CoursesController : ControllerBase
     [HttpGet("{id:guid}/students")]
     [Authorize(Roles = RolesNames.Teacher)]
     [SwaggerOperation(
-    Summary = "Get students in the current course",
-    Description = "Retrieves the students for the course. Require Teacher role"
+        Summary = "Get students in the current course",
+        Description = "Retrieves the students for the course. Require Teacher role"
     )]
     [SwaggerResponse(StatusCodes.Status200OK)]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized)]
+    [SwaggerResponse(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetCourseStudents(Guid id, CancellationToken token)
     {
         var students = await _serviceManager.CourseService.GetStudentsByCourseId(id, token);
         return Ok(students);
-    }
-
-    private bool IsStudent()
-        => User.IsInRole(RolesNames.Student);
-    private string? GetCurrentUserId()
-        => User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-    private bool IsStudentGettingUnauthorizedCourse(Guid studentId)
-    {
-        var isStudent = IsStudent();
-        if (!isStudent) return false;
-        var currentUserId = GetCurrentUserId();
-        return currentUserId is null || currentUserId != studentId.ToString();
     }
 }

--- a/LMS.Presentation/Controllers/CoursesController.cs
+++ b/LMS.Presentation/Controllers/CoursesController.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Claims;
-using LMS.Shared.Constants;
+﻿using LMS.Shared.Constants;
 using LMS.Shared.DTOs.CourseDtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -17,13 +16,11 @@ public class CoursesController : ControllerBase
 {
     private readonly IServiceManager _serviceManager;
     private readonly ILogger<CoursesController> _logger;
-    private readonly ControllerHelpers _controllerHelpers;
 
-    public CoursesController(IServiceManager serviceManager, ILogger<CoursesController> logger, ControllerHelpers controllerHelpers)
+    public CoursesController(IServiceManager serviceManager, ILogger<CoursesController> logger)
     {
         _serviceManager = serviceManager;
         _logger = logger;
-        _controllerHelpers = controllerHelpers;
     }
 
     [HttpGet]
@@ -52,8 +49,8 @@ public class CoursesController : ControllerBase
     {
         // If a student is requesting a course they're not in, return 403
         string? currentStudentId = null;
-        if (_controllerHelpers.IsStudent(User)) 
-            currentStudentId = _controllerHelpers.GetCurrentUserId(User);
+        if (ControllerHelpers.IsStudent(User)) 
+            currentStudentId = ControllerHelpers.GetCurrentUserId(User);
 
         var courseDto = await _serviceManager.CourseService.GetCourseById(id, currentStudentId, token);
         return Ok(courseDto);
@@ -71,8 +68,8 @@ public class CoursesController : ControllerBase
     public async Task<ActionResult<IReadOnlyCollection<CourseDto>>> GetByUserId(Guid id, CancellationToken token)
     {
         string? currentStudentId = null;
-        if (_controllerHelpers.IsStudent(User))
-            currentStudentId = _controllerHelpers.GetCurrentUserId(User);
+        if (ControllerHelpers.IsStudent(User))
+            currentStudentId = ControllerHelpers.GetCurrentUserId(User);
 
         var courseDto = await _serviceManager.CourseService.GetCourseByUserId(id, currentStudentId, token);
         return Ok(courseDto);
@@ -131,7 +128,7 @@ public class CoursesController : ControllerBase
     [SwaggerResponse(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetMyCourseParticipants(CancellationToken token)
     {
-        var userIdClaim = _controllerHelpers.GetCurrentUserId(User);
+        var userIdClaim = ControllerHelpers.GetCurrentUserId(User);
 
         if (!Guid.TryParse(userIdClaim, out var userId)) {
             return Unauthorized(new ProblemDetails {

--- a/LMS.Presentation/Controllers/ModulesController.cs
+++ b/LMS.Presentation/Controllers/ModulesController.cs
@@ -12,10 +12,9 @@ namespace LMS.Presentation.Controllers;
 [Route("api/modules")]
 [ApiController]
 [Authorize]
-public class ModulesController(IServiceManager serviceManager, ControllerHelpers controllerHelpers) : ControllerBase
+public class ModulesController(IServiceManager serviceManager) : ControllerBase
 {
     private readonly IServiceManager _serviceManager = serviceManager;
-    private readonly ControllerHelpers _controllerHelpers = controllerHelpers;
 
     private IModuleService moduleService => _serviceManager.ModuleService;
 

--- a/LMS.Presentation/Controllers/ModulesController.cs
+++ b/LMS.Presentation/Controllers/ModulesController.cs
@@ -1,3 +1,4 @@
+using LMS.Shared.Constants;
 using LMS.Shared.DTOs.ModuleDtos;
 using LMS.Shared.Pagination;
 using Microsoft.AspNetCore.Authorization;
@@ -11,12 +12,15 @@ namespace LMS.Presentation.Controllers;
 [Route("api/modules")]
 [ApiController]
 [Authorize]
-public class ModulesController(IServiceManager serviceManager) : ControllerBase
+public class ModulesController(IServiceManager serviceManager, ControllerHelpers controllerHelpers) : ControllerBase
 {
     private readonly IServiceManager _serviceManager = serviceManager;
+    private readonly ControllerHelpers _controllerHelpers = controllerHelpers;
+
     private IModuleService moduleService => _serviceManager.ModuleService;
 
     [HttpGet]
+    [Authorize(Roles = RolesNames.Teacher)]
     [SwaggerOperation(
         Summary = "Get all modules",
         Description = "Retrieves all modules in the system."
@@ -54,7 +58,7 @@ public class ModulesController(IServiceManager serviceManager) : ControllerBase
     }
 
     [HttpPost]
-    [Authorize(Roles = "Teacher")]
+    [Authorize(Roles = RolesNames.Teacher)]
     [SwaggerOperation(
         Summary = "Create a new module",
         Description = "Creates a new module for the specified course. Requires Teacher role."
@@ -69,7 +73,7 @@ public class ModulesController(IServiceManager serviceManager) : ControllerBase
     }
 
     [HttpPut("{id:guid}")]
-    [Authorize(Roles = "Teacher")]
+    [Authorize(Roles = RolesNames.Teacher)]
     [SwaggerOperation(
         Summary = "Update a module",
         Description = "Updates an existing module. Requires Teacher role."
@@ -83,7 +87,7 @@ public class ModulesController(IServiceManager serviceManager) : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
-    [Authorize(Roles = "Teacher")]
+    [Authorize(Roles = RolesNames.Teacher)]
     [SwaggerOperation(
         Summary = "Delete a module",
         Description = "Deletes an existing module. Requires Teacher role."

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -65,16 +65,20 @@ public class CourseService : ICourseService
         
         var userIds = course.Students.Select(u => u.Id);
         if (currentStudentId is not null && !userIds.Contains(currentStudentId))
-            throw new UserUnauthorizedException();
+            throw new UserForbiddenException("You're not allowed to access this course");
 
         var courseDto = _mapper.Map<CourseDto>(course);
         return courseDto;
     }
 
-    public async Task<CourseDto?> GetCourseByUserId(Guid id, CancellationToken token)
+    public async Task<CourseDto?> GetCourseByUserId(Guid id, string? currentStudentId, CancellationToken token)
     {
         var course = await _uow.Courses.GetCourseFromUserId(id, trackChanges: false, token)
             ?? throw new CourseNotFoundException(id);
+
+        var userIds = course.Students.Select(u => u.Id);
+        if (currentStudentId is not null && !userIds.Contains(currentStudentId))
+            throw new UserForbiddenException("You're not allowed to access this course");
 
         var courseDto = _mapper.Map<CourseDto>(course);
         return courseDto;

--- a/LMS.Test/Controllers/CoursesControllerTest.cs
+++ b/LMS.Test/Controllers/CoursesControllerTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Security.Claims;
 using Domain.Models.Exceptions;
+using LMS.Presentation;
 using LMS.Presentation.Controllers;
 using LMS.Shared.Constants;
 using LMS.Shared.DTOs.CourseDtos;
@@ -113,7 +114,7 @@ public class CoursesControllerTest
 
     [Fact]
     [Trait("Layer", "Controller")]
-    public async Task GetByUserId_WhenStudentRequestsDifferentUser_ReturnsUnauthorized()
+    public async Task GetByUserId_WhenStudentRequestsDifferentUser_ReturnsForbidden()
     {
         // Arrange
         var ct = CancellationToken.None;
@@ -121,6 +122,9 @@ public class CoursesControllerTest
         var currentStudentId = Guid.NewGuid();
 
         var courseServiceMock = new Mock<ICourseService>();
+        courseServiceMock
+            .Setup(s => s.GetCourseByUserId(requestedUserId, currentStudentId.ToString(), ct))
+            .Throws<UserForbiddenException>();
         var principal = new ClaimsPrincipal(new ClaimsIdentity(
         [
             new Claim(ClaimTypes.NameIdentifier, currentStudentId.ToString()),
@@ -130,11 +134,9 @@ public class CoursesControllerTest
         var controller = CreateController(courseServiceMock, principal);
 
         // Act
-        var result = await controller.GetByUserId(requestedUserId, ct);
-
         // Assert
-        Assert.IsType<UnauthorizedObjectResult>(result);
-        courseServiceMock.Verify(s => s.GetCourseByUserId(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        await Assert.ThrowsAsync<UserForbiddenException>(async () => await controller.GetByUserId(requestedUserId, ct));
+        courseServiceMock.Verify(s => s.GetCourseByUserId(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -374,7 +376,7 @@ public class CoursesControllerTest
         serviceManagerMock.SetupGet(s => s.CourseService).Returns(courseServiceMock.Object);
 
         var logger = Mock.Of<ILogger<CoursesController>>();
-        var controller = new CoursesController(serviceManagerMock.Object, logger)
+        var controller = new CoursesController(serviceManagerMock.Object, logger, new ControllerHelpers())
         {
             ControllerContext = new ControllerContext
             {

--- a/LMS.Test/Controllers/CoursesControllerTest.cs
+++ b/LMS.Test/Controllers/CoursesControllerTest.cs
@@ -376,7 +376,7 @@ public class CoursesControllerTest
         serviceManagerMock.SetupGet(s => s.CourseService).Returns(courseServiceMock.Object);
 
         var logger = Mock.Of<ILogger<CoursesController>>();
-        var controller = new CoursesController(serviceManagerMock.Object, logger, new ControllerHelpers())
+        var controller = new CoursesController(serviceManagerMock.Object, logger)
         {
             ControllerContext = new ControllerContext
             {

--- a/Service.Contracts/ICourseService.cs
+++ b/Service.Contracts/ICourseService.cs
@@ -7,7 +7,7 @@ public interface ICourseService
 {
     Task<PagedResult<CourseDto>> GetAllCourses(AllCoursesParams param, CancellationToken token);
     Task<CourseDto?> GetCourseById(Guid id, string? currentStudentId, CancellationToken token);
-    Task<CourseDto?> GetCourseByUserId(Guid id, CancellationToken token);
+    Task<CourseDto?> GetCourseByUserId(Guid id, string? currentStudentId, CancellationToken token);
     Task<CourseDto> CreateCourse(CreateCourseDto createCourseDto, CancellationToken token);
     Task UpdateCourse(Guid id, UpdateCourseDto updateCourseDto, CancellationToken token);
     Task DeleteCourse(Guid id, CancellationToken token);


### PR DESCRIPTION
This mostly just changes so the courses controller correctly returns 403forbidden instead 401unauthorized. The ProxyController already have code to get a new token and try again (rows 15 - 62, video in teams) which seems to work properly, so thinking it breaks when you're constantly starting/stopping the site. 

Modules and Activities don't have the same 403 checks as course does since it would require a lot of joins on the database (`.Include(a => a.Module).ThenInclude(m => m.Course).ThenInclude(c => c.Students)`) and unsure if we need / are supposed to use queries that long and complicated. Response time doesn't seems too bad tho (around 50 - 100ms on postman) so could maybe work.