### PR TITLE
Fix course participant counts

### DIFF
--- a/Domain.Contracts/Queries/IParticipantQuery.cs
+++ b/Domain.Contracts/Queries/IParticipantQuery.cs
@@ -6,4 +6,7 @@ public interface IParticipantQuery
 {
     Task<CourseParticipantsDto?> GetCourseParticipantsByUserId(Guid userId, CancellationToken token);
     Task<IReadOnlyCollection<CourseStudentDto>> GetStudentsByCourseId(Guid courseId, CancellationToken token);
+    Task<IReadOnlyDictionary<Guid, CourseParticipantCounts>> GetCourseParticipantCountsByCourseIds(
+        IReadOnlyCollection<Guid> courseIds,
+        CancellationToken token);
 }

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseOverviewModels.cs
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/CourseOverviewModels.cs
@@ -11,7 +11,7 @@ public class CourseStatisticsModel
     public int Modules { get; set; }
     public int Activities { get; set; }
     public int Students { get; set; }
-    public int Submissions { get; set; } = 0;
+    public int Teachers { get; set; } = 0;
 }
 
 public class ActivityModel

--- a/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/CourseStatisticsCard.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Components/TeacherCourseOverview/OverviewComponents/CourseStatisticsCard.razor
@@ -28,9 +28,9 @@
             </div>
 
             <div class="col-12 col-sm-6">
-                <StatisticTile Title="Inlämningar"
-                               Value="@Statistics.Submissions"
-                               Icon="bi bi-file-earmark-text"
+                <StatisticTile Title="Lärare"
+                               Value="@Statistics.Teachers"
+                               Icon="bi bi-people"
                                BackgroundClass="bg-warning-subtle"
                                IconColorClass="text-warning-emphasis" />
             </div>

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/Courses.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/Courses.razor
@@ -105,7 +105,7 @@
                                     </span>
                                 </span>
                                 <span class="modules-chip">@course.Modules.Count moduler</span>
-                                <span class="modules-chip">@course.NumberOfStudents deltagare</span>
+                                <span class="modules-chip">@course.TotalParticipants deltagare</span>
                                 <div class="py-1 ms-2">
                                     <i class="bi bi-calendar3" aria-hidden="true"></i>
                                     <span>@course.StartDateStr - @course.EndDateStr</span>

--- a/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
+++ b/LMS.Blazor/LMS.Blazor.Client/Pages/TeacherCourseOverview.razor
@@ -208,7 +208,8 @@ else
         {
             Modules = course.Modules?.Count ?? 0,
             Activities = course.Modules?.Sum(m => m.Activities?.Count ?? 0) ?? 0,
-            Students = course.NumberOfStudents
+            Students = course.NumberOfStudents,
+            Teachers = course.NumberOfTeachers
         };
     }
 

--- a/LMS.Infractructure/Data/MapperProfile.cs
+++ b/LMS.Infractructure/Data/MapperProfile.cs
@@ -14,7 +14,10 @@ public class MapperProfile : Profile
     {
         CreateMap<UserRegistrationDto, ApplicationUser>();
         CreateMap<UserDto, ApplicationUser>().ReverseMap();
-        CreateMap<Course, CourseDto>().ForMember(dest => dest.NumberOfStudents, opt => opt.MapFrom(c => c.Students.Count)).ReverseMap();
+        CreateMap<Course, CourseDto>()
+            .ForMember(dest => dest.NumberOfTeachers, opt => opt.Ignore())
+            .ForMember(dest => dest.NumberOfStudents, opt => opt.Ignore())
+            .ReverseMap();
         CreateMap<CreateCourseDto, Course>();
         CreateMap<CreateModuleDto, Module>();
         CreateMap<CourseModuleDto, Module>().ReverseMap();

--- a/LMS.Infractructure/Queries/ParticipantQuery.cs
+++ b/LMS.Infractructure/Queries/ParticipantQuery.cs
@@ -16,6 +16,41 @@ public class ParticipantQuery : IParticipantQuery
         _context = context;
     }
 
+    public async Task<IReadOnlyDictionary<Guid, CourseParticipantCounts>> GetCourseParticipantCountsByCourseIds(
+        IReadOnlyCollection<Guid> courseIds,
+        CancellationToken token)
+    {
+        if (courseIds.Count == 0)
+            return new Dictionary<Guid, CourseParticipantCounts>();
+
+        var counts = await (
+            from user in _context.Users.AsNoTracking()
+
+            join userRole in _context.UserRoles.AsNoTracking()
+                on user.Id equals userRole.UserId
+
+            join role in _context.Roles.AsNoTracking()
+                on userRole.RoleId equals role.Id
+
+            where user.CourseId != null
+                && courseIds.Contains(user.CourseId.Value)
+                && (role.Name == RolesNames.Student || role.Name == RolesNames.Teacher)
+
+            group role by user.CourseId!.Value into roleGroup
+
+            select new
+            {
+                CourseId = roleGroup.Key,
+                NumberOfTeachers = roleGroup.Count(role => role.Name == RolesNames.Teacher),
+                NumberOfStudents = roleGroup.Count(role => role.Name == RolesNames.Student)
+            }
+        ).ToListAsync(token);
+
+        return counts.ToDictionary(
+            count => count.CourseId,
+            count => new CourseParticipantCounts(count.NumberOfTeachers, count.NumberOfStudents));
+    }
+
     public async Task<CourseParticipantsDto?> GetCourseParticipantsByUserId(Guid userId, CancellationToken token)
     {
         var userIdStr = userId.ToString();

--- a/LMS.Infractructure/Repositories/CourseRepository.cs
+++ b/LMS.Infractructure/Repositories/CourseRepository.cs
@@ -43,7 +43,6 @@ public class CourseRepository(ApplicationDbContext context)
                         .Include(c => c.Modules)
                             .ThenInclude(m => m.Activities)
                                 .ThenInclude(a => a.Type)
-                        .Include(c => c.Students)
                         .OrderBy(c => c.StartDate)
                         .ToPagedResultAsync(param, token);
     }

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -3,7 +3,6 @@ using Domain.Contracts.Queries;
 using Domain.Contracts.Repositories;
 using Domain.Models.Entities;
 using Domain.Models.Exceptions;
-using LMS.Shared.Constants;
 using LMS.Shared.DTOs.CourseDtos;
 using LMS.Shared.Pagination;
 using Microsoft.Extensions.Logging;
@@ -49,12 +48,15 @@ public class CourseService : ICourseService
     public async Task<PagedResult<CourseDto>> GetAllCourses(AllCoursesParams param, CancellationToken token)
     {
         var result = await _uow.Courses.GetAllCourses(param, token);
+        var courseDtos = _mapper.Map<List<CourseDto>>(result.Items);
+        await FillParticipantCounts(courseDtos, token);
+
         return new PagedResult<CourseDto>
         {
             Page = result.Page,
             PageSize = result.PageSize,
             TotalItems = result.TotalItems,
-            Items = _mapper.Map<List<CourseDto>>(result.Items),
+            Items = courseDtos,
         };
     }
 
@@ -68,6 +70,7 @@ public class CourseService : ICourseService
             throw new UserForbiddenException("You're not allowed to access this course");
 
         var courseDto = _mapper.Map<CourseDto>(course);
+        await FillParticipantCounts([courseDto], token);
         return courseDto;
     }
 
@@ -81,6 +84,7 @@ public class CourseService : ICourseService
             throw new UserForbiddenException("You're not allowed to access this course");
 
         var courseDto = _mapper.Map<CourseDto>(course);
+        await FillParticipantCounts([courseDto], token);
         return courseDto;
     }
 
@@ -155,5 +159,21 @@ public class CourseService : ICourseService
     public async Task<IReadOnlyCollection<CourseStudentDto>> GetStudentsByCourseId(Guid courseId, CancellationToken token)
     {
         return await _participantQuery.GetStudentsByCourseId(courseId, token);
+    }
+
+    private async Task FillParticipantCounts(IReadOnlyCollection<CourseDto> courseDtos, CancellationToken token)
+    {
+        var countsByCourseId = await _participantQuery.GetCourseParticipantCountsByCourseIds(
+            courseDtos.Select(course => course.Id).ToArray(),
+            token);
+
+        foreach (var courseDto in courseDtos)
+        {
+            if (!countsByCourseId.TryGetValue(courseDto.Id, out var participantCounts))
+                continue;
+
+            courseDto.NumberOfTeachers = participantCounts.NumberOfTeachers;
+            courseDto.NumberOfStudents = participantCounts.NumberOfStudents;
+        }
     }
 }

--- a/LMS.Shared/DTOs/CourseDtos/CourseDto.cs
+++ b/LMS.Shared/DTOs/CourseDtos/CourseDto.cs
@@ -9,6 +9,9 @@ public sealed record CourseDto
     public string StartDateStr => StartDate.ToString("yyyy-MM-dd");
     public DateOnly EndDate {get; set; }
     public string EndDateStr => EndDate.ToString("yyyy-MM-dd");
+    public int NumberOfTeachers { get; set; }
     public int NumberOfStudents {get; set; }
+    public int TotalParticipants => NumberOfTeachers + NumberOfStudents;
+
     public ICollection<CourseModuleDto> Modules { get; set; } = [];
 }

--- a/LMS.Shared/DTOs/CourseDtos/CourseParticipantCounts.cs
+++ b/LMS.Shared/DTOs/CourseDtos/CourseParticipantCounts.cs
@@ -1,0 +1,6 @@
+﻿
+namespace LMS.Shared.DTOs.CourseDtos;
+
+public sealed record CourseParticipantCounts(
+    int NumberOfTeachers,
+    int NumberOfStudents);


### PR DESCRIPTION
Fixed `CourseDto` participant counts so students and teachers are counted separately instead of treating Course.Students as only students.

**Changes**
-Stops AutoMapper from mapping NumberOfStudents from Course.Students.Count
-Adds `FillParticipantCounts()` in `CourseService` to get number of students and teachers from `IParticipantQuery`  
-Adds CourseDto results with NumberOfTeachers and NumberOfStudents
-TotalParticipants derived from teacher + student counts
-Removs the Students include from the paged course list query to avoid loading all participants for list views

-Removed inlämningar that was always 0 and added lärare instead:
<img width="1132" height="622" alt="image" src="https://github.com/user-attachments/assets/1f8deedd-9cb7-4731-9c9d-a4098b292443" />
